### PR TITLE
Prevent from creating duplicated fields

### DIFF
--- a/generator/code_generator.go
+++ b/generator/code_generator.go
@@ -122,8 +122,12 @@ func newTypeDeclares(msgs []*resolver.Message, svc *resolver.Service) []*Type {
 							if !responseField.Used {
 								continue
 							}
+							fieldName := util.ToPublicGoVariable(responseField.Name)
+							if typ.HasField(fieldName) {
+								continue
+							}
 							typ.Fields = append(typ.Fields, &Field{
-								Name: util.ToPublicGoVariable(responseField.Name),
+								Name: fieldName,
 								Type: toTypeText(svc, responseField.Type),
 							})
 						}


### PR DESCRIPTION
If we declare message dependencies that refers to a resolver, it creates duplicated fields. For example the proto below

```
message Post {
  option (grpc.federation.message) = {
    resolver {
      method: "post.PostService/GetPost"
      request: [
        { field: "id", by: "$.id" }
      ]
      response: [ { name: "post", field: "post", autobind: true  } ]
    }
    messages: [
      { name: "user1", message: "User1", args: [{ inline: "post" }]},
      { name: "user2", message: "User2", args: [{ inline: "post" }]}
    ]
  };
  string id = 1;
  string title = 2;
  string content = 3;
  User1 user1 = 4 [(grpc.federation.field).by = "user1"];
  User2 user2 = 5 [(grpc.federation.field).by = "user2"];
}
```

generates the following struct which has two Post fields.

```
// Federation_PostArgument is argument for "federation.Post" message.
type Federation_PostArgument[T any] struct {
	Id     string
	Post   *post.Post
	Post   *post.Post
	User1  *User1
	User2  *User2
	Client T
}
```

IIUC, to prevent this, we should check if the same field already exists or not as we do for the message dependencies.