### PR TITLE
Remove unnecessary reference name checks

### DIFF
--- a/_examples/13_map/go.mod
+++ b/_examples/13_map/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	golang.org/x/sync v0.4.0
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20231012201019-e917dd12ba7a
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -34,4 +33,5 @@ require (
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20231012201019-e917dd12ba7a // indirect
 )

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2903,7 +2903,7 @@ func (r *Resolver) resolveMessageDependencies(ctx *context, files []*File) {
 			ctx := ctx.withDefIndex(defIdx)
 			for detIdx, detail := range def.Expr.Validation.Error.Details {
 				ctx := ctx.withErrDetailIndex(detIdx)
-				if graph := CreateMessageDependencyGraphByValidationErrorDetailMessages(ctx, msg, detail.Messages); graph != nil {
+				if graph := CreateMessageDependencyGraphByValidationErrorDetailMessages(msg, detail.Messages); graph != nil {
 					detail.DependencyGraph = graph
 					detail.Resolvers = graph.MessageResolverGroups(ctx)
 				}

--- a/source/location.go
+++ b/source/location.go
@@ -497,22 +497,6 @@ func MessageFieldByLocation(fileName, msgName, fieldName string) *Location {
 	}
 }
 
-// MessageFieldAliasLocation creates location for alias in grpc.federation.field option.
-func MessageFieldAliasLocation(fileName, msgName, fieldName string) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Field: &Field{
-				Name: fieldName,
-				Option: &FieldOption{
-					Alias: true,
-				},
-			},
-		},
-	}
-}
-
 // MessageFieldOneofLocation creates location for oneof in grpc.federation.field option.
 func MessageFieldOneofLocation(fileName, msgName, fieldName string) *Location {
 	return &Location{
@@ -581,26 +565,6 @@ func MessageFieldOneofByLocation(fileName, msgName, fieldName string) *Location 
 	}
 }
 
-// MessageFieldOneofDefLocation creates location for def in grpc.federation.field.oneof option.
-func MessageFieldOneofDefLocation(fileName, msgName, fieldName string, idx int) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Field: &Field{
-				Name: fieldName,
-				Option: &FieldOption{
-					Oneof: &FieldOneof{
-						VariableDefinitions: &VariableDefinitionOption{
-							Idx: idx,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 // MessageFieldOneofDefMessageLocation creates location for def[*].message in grpc.federation.field.oneof.
 func MessageFieldOneofDefMessageLocation(fileName, msgName, fieldName string, idx int) *Location {
 	return &Location{
@@ -637,83 +601,6 @@ func MessageFieldOneofDefMessageArgumentLocation(fileName, msgName, fieldName st
 							Message: &MessageExprOption{
 								Args: &ArgumentOption{
 									Idx: argIdx,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// MessageFieldOneofDefMessageArgumentNameLocation creates location for def[*].message.args[].name in grpc.federation.field.oneof.
-func MessageFieldOneofDefMessageArgumentNameLocation(fileName, msgName, fieldName string, idx, argIdx int) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Field: &Field{
-				Option: &FieldOption{
-					Oneof: &FieldOneof{
-						VariableDefinitions: &VariableDefinitionOption{
-							Idx: idx,
-							Message: &MessageExprOption{
-								Args: &ArgumentOption{
-									Idx:  argIdx,
-									Name: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// MessageFieldOneofDefMessageArgumentByLocation creates location for def[*].message.args[].by in grpc.federation.field.oneof.
-func MessageFieldOneofDefMessageArgumentByLocation(fileName, msgName, fieldName string, idx, argIdx int) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Field: &Field{
-				Name: fieldName,
-				Option: &FieldOption{
-					Oneof: &FieldOneof{
-						VariableDefinitions: &VariableDefinitionOption{
-							Idx: idx,
-							Message: &MessageExprOption{
-								Args: &ArgumentOption{
-									Idx: argIdx,
-									By:  true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// MessageFieldOneofDefMessageArgumentInlineLocation creates location for def[*].message.args[].inline in grpc.federation.field.oneof.
-func MessageFieldOneofDefMessageArgumentInlineLocation(fileName, msgName, fieldName string, idx, argIdx int) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Field: &Field{
-				Name: fieldName,
-				Option: &FieldOption{
-					Oneof: &FieldOneof{
-						VariableDefinitions: &VariableDefinitionOption{
-							Idx: idx,
-							Message: &MessageExprOption{
-								Args: &ArgumentOption{
-									Idx:    argIdx,
-									Inline: true,
 								},
 							},
 						},
@@ -1417,64 +1304,6 @@ func VariableDefinitionValidationDetailMessageArgumentLocation(fileName, msgName
 								Message: &MessageExprOption{
 									Args: &ArgumentOption{
 										Idx: argIdx,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// VariableDefinitionValidationDetailMessageArgumentByLocation creates location for def.validation[*].error.details[*].message[*].args[*].by in grpc.federation.message.
-func VariableDefinitionValidationDetailMessageArgumentByLocation(fileName, msgName string, defIdx, detIdx, msgIdx, argIdx int) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Option: &MessageOption{
-				VariableDefinitions: &VariableDefinitionOption{
-					Idx: defIdx,
-					Validation: &ValidationExprOption{
-						Detail: &ValidationDetailOption{
-							Idx: detIdx,
-							Message: &ValidationDetailMessageOption{
-								Idx: msgIdx,
-								Message: &MessageExprOption{
-									Args: &ArgumentOption{
-										Idx: argIdx,
-										By:  true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// VariableDefinitionValidationDetailMessageArgumentInlineLocation creates location for def.validation[*].error.details[*].message[*].args[*].inline in grpc.federation.message.
-func VariableDefinitionValidationDetailMessageArgumentInlineLocation(fileName, msgName string, defIdx, detIdx, msgIdx, argIdx int) *Location {
-	return &Location{
-		FileName: fileName,
-		Message: &Message{
-			Name: msgName,
-			Option: &MessageOption{
-				VariableDefinitions: &VariableDefinitionOption{
-					Idx: defIdx,
-					Validation: &ValidationExprOption{
-						Detail: &ValidationDetailOption{
-							Idx: detIdx,
-							Message: &ValidationDetailMessageOption{
-								Idx: msgIdx,
-								Message: &MessageExprOption{
-									Args: &ArgumentOption{
-										Idx:    argIdx,
-										Inline: true,
 									},
 								},
 							},

--- a/validator/testdata/valid_enum_value_reference.proto
+++ b/validator/testdata/valid_enum_value_reference.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package org.federation;
+
+import "federation.proto";
+import "nested_post.proto";
+
+option go_package = "example/federation;federation";
+
+service FederationService {
+  option (grpc.federation.service) = {
+    dependencies: [
+      { name: "post_service", service: "org.post.PostService" }
+    ]
+  };
+  rpc GetPost(GetPostRequest) returns (GetPostResponse) {};
+}
+
+message GetPostRequest {
+  string id = 1;
+}
+
+message GetPostResponse {
+  option (grpc.federation.message) = {
+    def {
+      name: "post"
+      message {
+        name: "Post"
+        args { name: "id", by: "$.id" }
+      }
+    }
+  };
+  Post post = 1 [(grpc.federation.field).by = "post"];
+}
+
+message Post {
+  option (grpc.federation.message) = {
+    def {
+      name: "res"
+      call {
+        method: "org.post.PostService/GetPost"
+        request { field: "id", by: "$.id" }
+      }
+    }
+    def { name: "post", by: "res.post", autobind: true }
+  };
+  string id = 1;
+  PostType type = 2 [(grpc.federation.field).by = "org.federation.PostType.FICTION"];
+}
+
+enum PostType {
+  UNKNOWN = 0;
+  FICTION = 1;
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -273,6 +273,7 @@ testdata/missing_enum_value_alias.proto:56:3: specified "alias" in grpc.federati
 56:    POST_TYPE_BAR = 2;
        ^
 `},
+		{file: "valid_enum_value_reference.proto", expected: ""},
 		{file: "missing_message_field_alias.proto", expected: `
 testdata/missing_message_field_alias.proto:80:3: specified "alias" in grpc.federation.message option, but "dup_body" field does not exist in "org.post.PostContent" message
 80:    string dup_body = 4;
@@ -486,8 +487,15 @@ testdata/invalid_validation_localized_message.proto:54:26: message must always r
 			if err != nil {
 				t.Fatal(err)
 			}
-			actual := "\n" + validator.Format(v.Validate(ctx, file))
-			if diff := cmp.Diff(actual, test.expected); diff != "" {
+			got := validator.Format(v.Validate(ctx, file))
+			if test.expected == "" {
+				if got != "" {
+					t.Errorf("expected to receive no validation error but got: %s", got)
+				}
+				return
+			}
+
+			if diff := cmp.Diff("\n"+got, test.expected); diff != "" {
 				t.Errorf("(-got, +want)\n%s", diff)
 			}
 		})


### PR DESCRIPTION
SSIA. Some reference name checks were unnecessary and caused the complication to fail when we referred to the enum values from CEL. So we decided to remove them since CEL checks their existence anyway.