### PR TITLE
Support list library

### DIFF
--- a/grpc/federation/cel.go
+++ b/grpc/federation/cel.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
 	celtypes "github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -190,6 +191,13 @@ func EvalCEL(env *cel.Env, expr string, vars []cel.EnvOption, args map[string]an
 	out, _, err := program.Eval(args)
 	if err != nil {
 		return nil, err
+	}
+	opt, ok := out.(*types.Optional)
+	if ok {
+		if opt == types.OptionalNone {
+			return reflect.Zero(outType).Interface(), nil
+		}
+		out = opt.GetValue()
 	}
 	if outType != nil {
 		return out.ConvertToNative(outType)

--- a/grpc/federation/cel.go
+++ b/grpc/federation/cel.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
 	celtypes "github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -192,9 +191,9 @@ func EvalCEL(env *cel.Env, expr string, vars []cel.EnvOption, args map[string]an
 	if err != nil {
 		return nil, err
 	}
-	opt, ok := out.(*types.Optional)
+	opt, ok := out.(*celtypes.Optional)
 	if ok {
-		if opt == types.OptionalNone {
+		if opt == celtypes.OptionalNone {
 			return reflect.Zero(outType).Interface(), nil
 		}
 		out = opt.GetValue()

--- a/grpc/federation/cel/lib.go
+++ b/grpc/federation/cel/lib.go
@@ -10,6 +10,7 @@ func NewLibrary() *Library {
 	return &Library{
 		subLibs: []cel.SingletonLibrary{
 			new(TimeLibrary),
+			new(ListLibrary),
 		},
 	}
 }

--- a/grpc/federation/cel/list.go
+++ b/grpc/federation/cel/list.go
@@ -1,0 +1,70 @@
+package cel
+
+import (
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/operators"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/parser"
+)
+
+const ListPackageName = "list"
+
+type ListLibrary struct {
+}
+
+func (lib *ListLibrary) LibraryName() string {
+	return packageName(ListPackageName)
+}
+
+func (lib *ListLibrary) CompileOptions() []cel.EnvOption {
+	opts := []cel.EnvOption{
+		cel.OptionalTypes(),
+		cel.Macros(
+			// range.reduce(accumulator, current, <expr>, <init>)
+			cel.ReceiverMacro("reduce", 4, makeReduce),
+
+			// range.first(var, <expr>)
+			// first macro is the shorthand version of the following expression
+			// <range>.filter(iter, expr)[?0]
+			cel.ReceiverMacro("first", 2, makeFirst),
+		),
+	}
+	return opts
+}
+
+func (lib *ListLibrary) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func makeReduce(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	accum, found := extractIdent(args[0])
+	if !found {
+		return nil, mef.NewError(args[0].ID(), "argument is not an identifier")
+	}
+	cur, found := extractIdent(args[1])
+	if !found {
+		return nil, mef.NewError(args[1].ID(), "argument is not an identifier")
+	}
+	reduce := args[2]
+	init := args[3]
+	condition := mef.NewLiteral(types.True)
+	accuExpr := mef.NewIdent(accum)
+	return mef.NewComprehension(target, cur, accum, init, condition, reduce, accuExpr), nil
+}
+
+func makeFirst(mef cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	filter, err := parser.MakeFilter(mef, target, args)
+	if err != nil {
+		return nil, err
+	}
+	return mef.NewCall(operators.OptIndex, filter, mef.NewLiteral(types.Int(0))), nil
+}
+
+func extractIdent(e ast.Expr) (string, bool) {
+	switch e.Kind() {
+	case ast.IdentKind:
+		return e.AsIdent(), true
+	}
+	return "", false
+}

--- a/grpc/federation/cel/list_test.go
+++ b/grpc/federation/cel/list_test.go
@@ -1,0 +1,93 @@
+package cel_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/go-cmp/cmp"
+
+	cellib "github.com/mercari/grpc-federation/grpc/federation/cel"
+)
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		args map[string]any
+		cmp  func(any) error
+	}{
+		{
+			name: "reduce",
+			expr: "[2, 3, 4].reduce(accum, cur, accum + cur, 1)",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				if diff := cmp.Diff(int(gotV), 10); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "first match",
+			expr: "[1, 2, 3, 4].first(v, v % 2 == 0)",
+			cmp: func(got any) error {
+				opt, ok := got.(*types.Optional)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				gotV, ok := opt.GetValue().(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", opt)
+				}
+				if diff := cmp.Diff(int(gotV), 2); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "first not match",
+			expr: "[1, 2, 3, 4].first(v, v == 5)",
+			cmp: func(got any) error {
+				gotV, ok := got.(*types.Optional)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				if gotV != types.OptionalNone {
+					return fmt.Errorf("invalid optional type: %v", gotV)
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := cel.NewEnv(
+				cel.Lib(new(cellib.ListLibrary)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ast, iss := env.Compile(test.expr)
+			if iss.Err() != nil {
+				t.Fatal(iss.Err())
+			}
+			program, err := env.Program(ast)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, _, err := program.Eval(test.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := test.cmp(out); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2865,7 +2865,10 @@ func (r *Resolver) fromCELType(ctx *context, typ *cel.Type) (*Type, error) {
 			types.Message,
 			descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL,
 		)
+	case celtypes.OpaqueKind:
+		return r.fromCELType(ctx, typ.Parameters()[0])
 	}
+
 	return nil, errors.New("unknown type is required")
 }
 


### PR DESCRIPTION
The list library adds the following two macros.

- `reduce` : reduce operation for list value
  - e.g.) `[1, 2, 3, 4, 5].reduce(accum, cur, accum + cur, 0)` => `15`
  - FYI: https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce

- `first` : return first matched value from list value
  - e.g.) `[1, 2, 3, 4, 5].first(v, v % 2 == 0)` => `2`