### PR TITLE
Support uuid and rand library for CEL operation

### DIFF
--- a/_examples/01_minimum/go.mod
+++ b/_examples/01_minimum/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/01_minimum/go.sum
+++ b/_examples/01_minimum/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/02_simple/go.mod
+++ b/_examples/02_simple/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/02_simple/go.sum
+++ b/_examples/02_simple/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/03_custom_resolver/go.mod
+++ b/_examples/03_custom_resolver/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/03_custom_resolver/go.sum
+++ b/_examples/03_custom_resolver/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/04_timeout/go.mod
+++ b/_examples/04_timeout/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/04_timeout/go.sum
+++ b/_examples/04_timeout/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/05_async/go.mod
+++ b/_examples/05_async/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/05_async/go.sum
+++ b/_examples/05_async/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/06_alias/go.mod
+++ b/_examples/06_alias/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/06_alias/go.sum
+++ b/_examples/06_alias/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/07_autobind/go.mod
+++ b/_examples/07_autobind/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/07_autobind/go.sum
+++ b/_examples/07_autobind/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/08_literal/go.mod
+++ b/_examples/08_literal/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/08_literal/go.sum
+++ b/_examples/08_literal/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/09_multi_user/go.mod
+++ b/_examples/09_multi_user/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/09_multi_user/go.sum
+++ b/_examples/09_multi_user/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/10_oneof/go.mod
+++ b/_examples/10_oneof/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/10_oneof/go.sum
+++ b/_examples/10_oneof/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/11_multi_service/go.mod
+++ b/_examples/11_multi_service/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/11_multi_service/go.sum
+++ b/_examples/11_multi_service/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/12_validation/go.mod
+++ b/_examples/12_validation/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect

--- a/_examples/12_validation/go.sum
+++ b/_examples/12_validation/go.sum
@@ -18,6 +18,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=

--- a/_examples/13_map/go.mod
+++ b/_examples/13_map/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/13_map/go.sum
+++ b/_examples/13_map/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/_examples/14_condition/go.mod
+++ b/_examples/14_condition/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect

--- a/_examples/14_condition/go.sum
+++ b/_examples/14_condition/go.sum
@@ -20,6 +20,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/goccy/go-yaml v1.11.0
 	github.com/google/cel-go v0.18.1
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.3.0
 	github.com/jessevdk/go-flags v1.5.0
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=

--- a/grpc/federation/cel/lib.go
+++ b/grpc/federation/cel/lib.go
@@ -11,6 +11,8 @@ func NewLibrary() *Library {
 		subLibs: []cel.SingletonLibrary{
 			new(TimeLibrary),
 			new(ListLibrary),
+			new(RandLibrary),
+			new(UUIDLibrary),
 		},
 	}
 }

--- a/grpc/federation/cel/rand.go
+++ b/grpc/federation/cel/rand.go
@@ -111,7 +111,7 @@ func (lib *RandLibrary) CompileOptions() []cel.EnvOption {
 			cel.MemberOverload(createRandID("seed_source_int"), []*cel.Type{SourceType, cel.IntType}, cel.BoolType,
 				cel.BinaryBinding(func(self, seed ref.Val) ref.Val {
 					self.(*Source).Seed(int64(seed.(types.Int)))
-					return types.Bool(types.True)
+					return types.True
 				}),
 			),
 		),
@@ -122,7 +122,7 @@ func (lib *RandLibrary) CompileOptions() []cel.EnvOption {
 			cel.Overload(createRandID("new_source_rand"), []*cel.Type{SourceType}, RandType,
 				cel.UnaryBinding(func(source ref.Val) ref.Val {
 					return &Rand{
-						Rand: rand.New(source.(*Source)),
+						Rand: rand.New(source.(*Source)), //nolint:gosec
 					}
 				}),
 			),
@@ -212,7 +212,7 @@ func (lib *RandLibrary) CompileOptions() []cel.EnvOption {
 			cel.MemberOverload(createRandID("seed_rand_int_bool"), []*cel.Type{RandType, cel.IntType}, cel.BoolType,
 				cel.BinaryBinding(func(self, seed ref.Val) ref.Val {
 					self.(*Rand).Seed(int64(seed.(types.Int)))
-					return types.Bool(types.True)
+					return types.True
 				}),
 			),
 		),

--- a/grpc/federation/cel/rand.go
+++ b/grpc/federation/cel/rand.go
@@ -1,0 +1,233 @@
+package cel
+
+import (
+	"math/rand"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+const RandPackageName = "rand"
+
+var (
+	SourceType = types.NewObjectType(createRandName("Source"))
+	RandType   = types.NewObjectType(createRandName("Rand"))
+)
+
+type Source struct {
+	rand.Source
+}
+
+func (s *Source) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return s.Source, nil
+}
+
+func (s *Source) ConvertToType(typeValue ref.Type) ref.Val {
+	return types.NewErr("grpc.federation.rand: source type conversion does not support")
+}
+
+func (s *Source) Equal(other ref.Val) ref.Val {
+	if o, ok := other.(*Source); ok {
+		return types.Bool(s.Int63() == o.Int63())
+	}
+	return types.False
+}
+
+func (s *Source) Type() ref.Type {
+	return SourceType
+}
+
+func (s *Source) Value() any {
+	return s.Source
+}
+
+type Rand struct {
+	*rand.Rand
+}
+
+func (r *Rand) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return r.Rand, nil
+}
+
+func (r *Rand) ConvertToType(typeValue ref.Type) ref.Val {
+	return types.NewErr("grpc.federation.rand: rand type conversion does not support")
+}
+
+func (r *Rand) Equal(other ref.Val) ref.Val {
+	if o, ok := other.(*Rand); ok {
+		return types.Bool(r.Int() == o.Int())
+	}
+	return types.False
+}
+
+func (r *Rand) Type() ref.Type {
+	return RandType
+}
+
+func (r *Rand) Value() any {
+	return r.Rand
+}
+
+type RandLibrary struct {
+}
+
+func (lib *RandLibrary) LibraryName() string {
+	return packageName(RandPackageName)
+}
+
+func createRandName(name string) string {
+	return createName(RandPackageName, name)
+}
+
+func createRandID(name string) string {
+	return createID(RandPackageName, name)
+}
+
+func (lib *RandLibrary) CompileOptions() []cel.EnvOption {
+	opts := []cel.EnvOption{
+		// Source functions
+		cel.Function(
+			createRandName("newSource"),
+			cel.Overload(createRandID("new_source_int_source"), []*cel.Type{cel.IntType}, SourceType,
+				cel.UnaryBinding(func(seed ref.Val) ref.Val {
+					return &Source{
+						Source: rand.NewSource(int64(seed.(types.Int))),
+					}
+				}),
+			),
+		),
+		cel.Function(
+			"int63",
+			cel.MemberOverload(createRandID("int63_source_int"), []*cel.Type{SourceType}, cel.IntType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Int(self.(*Source).Int63())
+				}),
+			),
+		),
+		cel.Function(
+			"seed",
+			cel.MemberOverload(createRandID("seed_source_int"), []*cel.Type{SourceType, cel.IntType}, cel.BoolType,
+				cel.BinaryBinding(func(self, seed ref.Val) ref.Val {
+					self.(*Source).Seed(int64(seed.(types.Int)))
+					return types.Bool(types.True)
+				}),
+			),
+		),
+
+		// Rand functions
+		cel.Function(
+			createRandName("new"),
+			cel.Overload(createRandID("new_source_rand"), []*cel.Type{SourceType}, RandType,
+				cel.UnaryBinding(func(source ref.Val) ref.Val {
+					return &Rand{
+						Rand: rand.New(source.(*Source)),
+					}
+				}),
+			),
+		),
+		cel.Function(
+			"expFloat64",
+			cel.MemberOverload(createRandID("exp_float64_rand_double"), []*cel.Type{RandType}, cel.DoubleType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Double(self.(*Rand).ExpFloat64())
+				}),
+			),
+		),
+		cel.Function(
+			"float32",
+			cel.MemberOverload(createRandID("float32_rand_double"), []*cel.Type{RandType}, cel.DoubleType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Double(self.(*Rand).Float32())
+				}),
+			),
+		),
+		cel.Function(
+			"float64",
+			cel.MemberOverload(createRandID("float64_rand_double"), []*cel.Type{RandType}, cel.DoubleType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Double(self.(*Rand).Float64())
+				}),
+			),
+		),
+		cel.Function(
+			"int",
+			cel.MemberOverload(createRandID("int_rand_int"), []*cel.Type{RandType}, cel.IntType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Int(self.(*Rand).Int())
+				}),
+			),
+		),
+		cel.Function(
+			"int31",
+			cel.MemberOverload(createRandID("int31_rand_int"), []*cel.Type{RandType}, cel.IntType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Int(self.(*Rand).Int31())
+				}),
+			),
+		),
+		cel.Function(
+			"int31n",
+			cel.MemberOverload(createRandID("int31n_rand_int"), []*cel.Type{RandType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(func(self, n ref.Val) ref.Val {
+					return types.Int(self.(*Rand).Int31n(int32(n.(types.Int))))
+				}),
+			),
+		),
+		cel.Function(
+			"int63",
+			cel.MemberOverload(createRandID("int63_rand_int"), []*cel.Type{RandType}, cel.IntType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Int(self.(*Rand).Int63())
+				}),
+			),
+		),
+		cel.Function(
+			"int63n",
+			cel.MemberOverload(createRandID("int63n_rand_int"), []*cel.Type{RandType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(func(self, n ref.Val) ref.Val {
+					return types.Int(self.(*Rand).Int63n(int64(n.(types.Int))))
+				}),
+			),
+		),
+		cel.Function(
+			"intn",
+			cel.MemberOverload(createRandID("intn_rand_int"), []*cel.Type{RandType, cel.IntType}, cel.IntType,
+				cel.BinaryBinding(func(self, n ref.Val) ref.Val {
+					return types.Int(self.(*Rand).Intn(int(n.(types.Int))))
+				}),
+			),
+		),
+		cel.Function(
+			"normFloat64",
+			cel.MemberOverload(createRandID("norm_float64_rand_double"), []*cel.Type{RandType}, cel.DoubleType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Double(self.(*Rand).NormFloat64())
+				}),
+			),
+		),
+		cel.Function(
+			"seed",
+			cel.MemberOverload(createRandID("seed_rand_int_bool"), []*cel.Type{RandType, cel.IntType}, cel.BoolType,
+				cel.BinaryBinding(func(self, seed ref.Val) ref.Val {
+					self.(*Rand).Seed(int64(seed.(types.Int)))
+					return types.Bool(types.True)
+				}),
+			),
+		),
+		cel.Function(
+			"uint32",
+			cel.MemberOverload(createRandID("uint32_rand_uint"), []*cel.Type{RandType}, cel.UintType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Uint(self.(*Rand).Uint32())
+				}),
+			),
+		),
+	}
+	return opts
+}
+
+func (lib *RandLibrary) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}

--- a/grpc/federation/cel/rand_test.go
+++ b/grpc/federation/cel/rand_test.go
@@ -1,0 +1,277 @@
+package cel_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/go-cmp/cmp"
+
+	cellib "github.com/mercari/grpc-federation/grpc/federation/cel"
+)
+
+func TestRand(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		args map[string]any
+		cmp  func(any) error
+	}{
+		// Source functions
+		{
+			name: "newSource",
+			expr: "grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())",
+			cmp: func(got any) error {
+				gotV, ok := got.(*cellib.Source)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()).Int63()
+				if diff := cmp.Diff(gotV.Int63(), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "int63",
+			expr: "grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()).int63()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()).Int63()
+				if diff := cmp.Diff(int64(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "seed",
+			expr: "grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()).seed(10)",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Bool)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				if diff := cmp.Diff(bool(gotV), true); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+
+		// Rand functions
+		{
+			name: "new",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()))",
+			cmp: func(got any) error {
+				gotV, ok := got.(*cellib.Rand)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int()
+				if diff := cmp.Diff(int(gotV.Int()), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "expFloat64",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).expFloat64()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Double)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).ExpFloat64()
+				if diff := cmp.Diff(float64(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "float32",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).float32()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Double)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Float32()
+				if diff := cmp.Diff(float32(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "float64",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).float64()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Double)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Float64()
+				if diff := cmp.Diff(float64(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "int",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).int()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int()
+				if diff := cmp.Diff(int(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "int31",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).int31()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int31()
+				if diff := cmp.Diff(int32(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "int31n",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).int31n(10)",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int31n(10)
+				if diff := cmp.Diff(int32(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "rand_int63",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).int63()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int63()
+				if diff := cmp.Diff(int64(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "int63n",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).int63n(10)",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int63n(10)
+				if diff := cmp.Diff(int64(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "intn",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).intn(10)",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Intn(10)
+				if diff := cmp.Diff(int(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "normFloat64",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).normFloat64()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Double)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).NormFloat64()
+				if diff := cmp.Diff(float64(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "uint32",
+			expr: "grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())).uint32()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Uint)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Uint32()
+				if diff := cmp.Diff(uint32(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := cel.NewEnv(
+				cel.Lib(new(cellib.RandLibrary)),
+				cel.Lib(new(cellib.TimeLibrary)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ast, iss := env.Compile(test.expr)
+			if iss.Err() != nil {
+				t.Fatal(iss.Err())
+			}
+			program, err := env.Program(ast)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, _, err := program.Eval(test.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := test.cmp(out); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/grpc/federation/cel/rand_test.go
+++ b/grpc/federation/cel/rand_test.go
@@ -75,8 +75,8 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int()
-				if diff := cmp.Diff(int(gotV.Int()), expected); diff != "" {
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int() //nolint: gosec
+				if diff := cmp.Diff(gotV.Int(), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
 				return nil
@@ -90,7 +90,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).ExpFloat64()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).ExpFloat64() //nolint: gosec
 				if diff := cmp.Diff(float64(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -105,7 +105,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Float32()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Float32() //nolint: gosec
 				if diff := cmp.Diff(float32(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -120,7 +120,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Float64()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Float64() //nolint: gosec
 				if diff := cmp.Diff(float64(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -135,7 +135,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int() //nolint: gosec
 				if diff := cmp.Diff(int(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -150,7 +150,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int31()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int31() //nolint: gosec
 				if diff := cmp.Diff(int32(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -165,7 +165,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int31n(10)
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int31n(10) //nolint: gosec
 				if diff := cmp.Diff(int32(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -180,7 +180,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int63()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int63() //nolint: gosec
 				if diff := cmp.Diff(int64(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -195,7 +195,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int63n(10)
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Int63n(10) //nolint: gosec
 				if diff := cmp.Diff(int64(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -210,7 +210,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Intn(10)
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Intn(10) //nolint: gosec
 				if diff := cmp.Diff(int(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -225,7 +225,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).NormFloat64()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).NormFloat64() //nolint: gosec
 				if diff := cmp.Diff(float64(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}
@@ -240,7 +240,7 @@ func TestRand(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Uint32()
+				expected := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())).Uint32() //nolint: gosec
 				if diff := cmp.Diff(uint32(gotV), expected); diff != "" {
 					return fmt.Errorf("(-got, +want)\n%s", diff)
 				}

--- a/grpc/federation/cel/uuid.go
+++ b/grpc/federation/cel/uuid.go
@@ -1,0 +1,151 @@
+package cel
+
+import (
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/uuid"
+)
+
+const UUIDPackageName = "uuid"
+
+var (
+	UUIDType = types.NewObjectType(createUUIDName("UUID"))
+)
+
+type UUID struct {
+	uuid.UUID
+}
+
+func (u UUID) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	return u.UUID, nil
+}
+
+func (u UUID) ConvertToType(typeValue ref.Type) ref.Val {
+	return types.NewErr("grpc.federation.uuid: uuid type conversion does not support")
+}
+
+func (u UUID) Equal(other ref.Val) ref.Val {
+	if o, ok := other.(UUID); ok {
+		return types.Bool(u.String() == o.String())
+	}
+	return types.False
+}
+
+func (u UUID) Type() ref.Type {
+	return UUIDType
+}
+
+func (u UUID) Value() any {
+	return u.UUID
+}
+
+type UUIDLibrary struct {
+}
+
+func (lib *UUIDLibrary) LibraryName() string {
+	return packageName(UUIDPackageName)
+}
+
+func createUUIDName(name string) string {
+	return createName(UUIDPackageName, name)
+}
+
+func createUUIDID(name string) string {
+	return createID(UUIDPackageName, name)
+}
+
+func (lib *UUIDLibrary) CompileOptions() []cel.EnvOption {
+	opts := []cel.EnvOption{
+		// UUID functions
+		cel.Function(
+			createUUIDName("new"),
+			cel.Overload(createUUIDID("new_uuid"), []*cel.Type{}, UUIDType,
+				cel.FunctionBinding(func(_ ...ref.Val) ref.Val {
+					return &UUID{
+						UUID: uuid.New(),
+					}
+				}),
+			),
+		),
+		cel.Function(
+			createUUIDName("newRandom"),
+			cel.Overload(createUUIDID("new_random_uuid"), []*cel.Type{}, UUIDType,
+				cel.FunctionBinding(func(_ ...ref.Val) ref.Val {
+					id, err := uuid.NewRandom()
+					if err != nil {
+						return types.NewErr(err.Error())
+					}
+					return &UUID{UUID: id}
+				}),
+			),
+		),
+		cel.Function(
+			createUUIDName("newRandomFromRand"),
+			cel.Overload(createUUIDID("new_random_from_rand_uuid"), []*cel.Type{RandType}, UUIDType,
+				cel.UnaryBinding(func(rand ref.Val) ref.Val {
+					id, err := uuid.NewRandomFromReader(rand.(*Rand))
+					if err != nil {
+						return types.NewErr(err.Error())
+					}
+					return &UUID{UUID: id}
+				}),
+			),
+		),
+		cel.Function(
+			"domain",
+			cel.MemberOverload(createRandID("domain_uuid_string"), []*cel.Type{UUIDType}, cel.UintType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Uint(self.(*UUID).Domain())
+				}),
+			),
+		),
+		cel.Function(
+			"id",
+			cel.MemberOverload(createRandID("id_uuid_string"), []*cel.Type{UUIDType}, cel.UintType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Uint(self.(*UUID).ID())
+				}),
+			),
+		),
+		cel.Function(
+			"time",
+			cel.MemberOverload(createRandID("time_uuid_int"), []*cel.Type{UUIDType}, cel.IntType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Int(self.(*UUID).Time())
+				}),
+			),
+		),
+		cel.Function(
+			"urn",
+			cel.MemberOverload(createRandID("urn_uuid_string"), []*cel.Type{UUIDType}, cel.StringType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.String(self.(*UUID).URN())
+				}),
+			),
+		),
+		cel.Function(
+			"string",
+			cel.MemberOverload(createRandID("string_uuid_string"), []*cel.Type{UUIDType}, cel.StringType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.String(self.(*UUID).String())
+				}),
+			),
+		),
+		cel.Function(
+			"version",
+			cel.MemberOverload(createRandID("version_uuid_uint"), []*cel.Type{UUIDType}, cel.UintType,
+				cel.UnaryBinding(func(self ref.Val) ref.Val {
+					return types.Uint(self.(*UUID).Version())
+				}),
+			),
+		),
+	}
+	return opts
+}
+
+func (lib *UUIDLibrary) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}

--- a/grpc/federation/cel/uuid_test.go
+++ b/grpc/federation/cel/uuid_test.go
@@ -1,0 +1,216 @@
+package cel_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+
+	cellib "github.com/mercari/grpc-federation/grpc/federation/cel"
+)
+
+func TestUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		args map[string]any
+		cmp  func(any) error
+	}{
+		// UUID functions
+		{
+			name: "new",
+			expr: "grpc.federation.uuid.new()",
+			cmp: func(got any) error {
+				gotV, ok := got.(*cellib.UUID)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				if len(gotV.UUID) == 0 {
+					return fmt.Errorf("failed to get uuid")
+				}
+				return nil
+			},
+		},
+		{
+			name: "newRandom",
+			expr: "grpc.federation.uuid.newRandom()",
+			cmp: func(got any) error {
+				gotV, ok := got.(*cellib.UUID)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				if len(gotV.UUID) == 0 {
+					return fmt.Errorf("failed to get uuid")
+				}
+				return nil
+			},
+		},
+		{
+			name: "newRandomFromRand",
+			expr: "grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix())))",
+			cmp: func(got any) error {
+				gotV, ok := got.(*cellib.UUID)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				id, err := uuid.NewRandomFromReader(r)
+				if err != nil {
+					return err
+				}
+				expected := id.String()
+				if diff := cmp.Diff(gotV.UUID.String(), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "domain",
+			expr: "grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()))).domain()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Uint)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				id, err := uuid.NewRandomFromReader(r)
+				if err != nil {
+					return err
+				}
+				expected := id.Domain()
+				if diff := cmp.Diff(uuid.Domain(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "id",
+			expr: "grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()))).id()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Uint)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				id, err := uuid.NewRandomFromReader(r)
+				if err != nil {
+					return err
+				}
+				expected := id.ID()
+				if diff := cmp.Diff(uint32(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "time",
+			expr: "grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()))).time()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Int)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				id, err := uuid.NewRandomFromReader(r)
+				if err != nil {
+					return err
+				}
+				expected := id.Time()
+				if diff := cmp.Diff(uuid.Time(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "urn",
+			expr: "grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()))).urn()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.String)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				id, err := uuid.NewRandomFromReader(r)
+				if err != nil {
+					return err
+				}
+				expected := id.URN()
+				if diff := cmp.Diff(string(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "string",
+			expr: "grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(grpc.federation.time.date(2023, 12, 25, 12, 0, 0, 0, grpc.federation.time.UTC).unix()))).string()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.String)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				id, err := uuid.NewRandomFromReader(r)
+				if err != nil {
+					return err
+				}
+				expected := id.String()
+				if diff := cmp.Diff(string(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+		{
+			name: "version",
+			expr: "grpc.federation.uuid.new().version()",
+			cmp: func(got any) error {
+				gotV, ok := got.(types.Uint)
+				if !ok {
+					return fmt.Errorf("invalid result type: %T", got)
+				}
+				expected := uuid.New().Version()
+				if diff := cmp.Diff(uuid.Version(gotV), expected); diff != "" {
+					return fmt.Errorf("(-got, +want)\n%s", diff)
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env, err := cel.NewEnv(
+				cel.Lib(new(cellib.UUIDLibrary)),
+				cel.Lib(new(cellib.RandLibrary)),
+				cel.Lib(new(cellib.TimeLibrary)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ast, iss := env.Compile(test.expr)
+			if iss.Err() != nil {
+				t.Fatal(iss.Err())
+			}
+			program, err := env.Program(ast)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, _, err := program.Eval(test.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := test.cmp(out); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/grpc/federation/cel/uuid_test.go
+++ b/grpc/federation/cel/uuid_test.go
@@ -26,7 +26,7 @@ func TestUUID(t *testing.T) {
 			name: "new",
 			expr: "grpc.federation.uuid.new()",
 			cmp: func(got any) error {
-				gotV, ok := got.(*cellib.UUID)
+				gotV, ok := got.(*cellib.UUID) //nolint: staticcheck
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
@@ -40,7 +40,7 @@ func TestUUID(t *testing.T) {
 			name: "newRandom",
 			expr: "grpc.federation.uuid.newRandom()",
 			cmp: func(got any) error {
-				gotV, ok := got.(*cellib.UUID)
+				gotV, ok := got.(*cellib.UUID) //nolint: staticcheck
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
@@ -58,7 +58,7 @@ func TestUUID(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())) //nolint: gosec
 				id, err := uuid.NewRandomFromReader(r)
 				if err != nil {
 					return err
@@ -78,7 +78,7 @@ func TestUUID(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())) //nolint: gosec
 				id, err := uuid.NewRandomFromReader(r)
 				if err != nil {
 					return err
@@ -98,7 +98,7 @@ func TestUUID(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())) //nolint: gosec
 				id, err := uuid.NewRandomFromReader(r)
 				if err != nil {
 					return err
@@ -118,7 +118,7 @@ func TestUUID(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())) //nolint: gosec
 				id, err := uuid.NewRandomFromReader(r)
 				if err != nil {
 					return err
@@ -138,7 +138,7 @@ func TestUUID(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())) //nolint: gosec
 				id, err := uuid.NewRandomFromReader(r)
 				if err != nil {
 					return err
@@ -158,7 +158,7 @@ func TestUUID(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("invalid result type: %T", got)
 				}
-				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix()))
+				r := rand.New(rand.NewSource(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC).Unix())) //nolint: gosec
 				id, err := uuid.NewRandomFromReader(r)
 				if err != nil {
 					return err


### PR DESCRIPTION
When sending a gRPC request to a dependent service, the idempotency-key may be sent. In this case, uuid is often used, so it is supported as a standard library.

- `grpc.federation.uuid.new().string()` : generate uuid and returns it as a string type
- `grpc.federation.uuid.newRandomFromRand(grpc.federation.rand.new(grpc.federation.rand.newSource(1)))` : generates uuid from fixed seed value