### PR TITLE
Rename Type and Ref field of resolver.Type

### DIFF
--- a/internal/testutil/cmpopt.go
+++ b/internal/testutil/cmpopt.go
@@ -24,7 +24,7 @@ func ResolverCmpOpts() []cmp.Option {
 		cmpopts.IgnoreFields(resolver.AllMessageDependencyGraphNode{}, "Parent", "Children", "Message.Rule"),
 		cmpopts.IgnoreFields(resolver.ValidationErrorDetail{}, "DependencyGraph", "Resolvers"),
 		cmpopts.IgnoreFields(resolver.AutoBindField{}, "VariableDefinition"),
-		cmpopts.IgnoreFields(resolver.Type{}, "Ref.Rule", "Enum.Rule", "OneofField"),
+		cmpopts.IgnoreFields(resolver.Type{}, "Message.Rule", "Enum.Rule", "OneofField"),
 		cmpopts.IgnoreFields(resolver.Oneof{}, "Message"),
 		cmpopts.IgnoreFields(resolver.Field{}, "Oneof.Message", "Oneof.Fields"),
 		cmpopts.IgnoreFields(resolver.Value{}, "CEL", "Const"),

--- a/resolver/candidates.go
+++ b/resolver/candidates.go
@@ -43,8 +43,8 @@ func (c ValueCandidates) Filter(typ *Type) ValueCandidates {
 			ret = append(ret, cc)
 			continue
 		}
-		if cc.Type.Ref == nil && cc.Type.Enum == nil {
-			if cc.Type.Type == typ.Type {
+		if cc.Type.Message == nil && cc.Type.Enum == nil {
+			if cc.Type.Kind == typ.Kind {
 				ret = append(ret, cc)
 				continue
 			}
@@ -57,7 +57,7 @@ func (c ValueCandidates) Filter(typ *Type) ValueCandidates {
 			ret = append(ret, cc)
 			continue
 		}
-		if cc.Type.Ref != nil && typ.Ref != nil && cc.Type.Ref == typ.Ref {
+		if cc.Type.Message != nil && typ.Message != nil && cc.Type.Message == typ.Message {
 			ret = append(ret, cc)
 			continue
 		}

--- a/resolver/format.go
+++ b/resolver/format.go
@@ -567,7 +567,7 @@ func (c *ConstValue) ProtoFormat(opt *ProtoFormatOption) string {
 		return fmt.Sprintf(`envs: [%s]`, strings.Join(elems, ", "))
 	}
 
-	switch c.Type.Type {
+	switch c.Type.Kind {
 	case types.Enum:
 		if c.Type.Repeated {
 			var elems []string
@@ -578,7 +578,7 @@ func (c *ConstValue) ProtoFormat(opt *ProtoFormatOption) string {
 		}
 		return fmt.Sprintf("enum: %q", c.Value.(*EnumValue).FQDN())
 	case types.Message:
-		msg := c.Type.Ref
+		msg := c.Type.Message
 		if c.Type.Repeated {
 			var elems []string
 			for _, v := range c.Value.([]map[string]*Value) {

--- a/resolver/message.go
+++ b/resolver/message.go
@@ -14,8 +14,8 @@ func NewMessage(name string, fields []*Field) *Message {
 
 func NewMessageType(msg *Message, repeated bool) *Type {
 	return &Type{
-		Type:     types.Message,
-		Ref:      msg,
+		Kind:     types.Message,
+		Message:  msg,
 		Repeated: repeated,
 	}
 }
@@ -380,10 +380,10 @@ func (m *Message) GoPackageDependencies() []*GoPackage {
 	}
 	seenMsgMap := make(map[*Message]struct{})
 	for _, field := range m.Fields {
-		if field.Type.Ref == nil {
+		if field.Type.Message == nil {
 			continue
 		}
-		for _, gopkg := range getGoPackageDependencies(gopkg, field.Type.Ref, seenMsgMap) {
+		for _, gopkg := range getGoPackageDependencies(gopkg, field.Type.Message, seenMsgMap) {
 			pkgMap[gopkg] = struct{}{}
 		}
 	}
@@ -401,13 +401,13 @@ func getGoPackageDependencies(base *GoPackage, msg *Message, seenMsgMap map[*Mes
 	}
 	seenMsgMap[msg] = struct{}{}
 	for _, field := range msg.Fields {
-		if field.Type.Ref == nil {
+		if field.Type.Message == nil {
 			continue
 		}
-		if _, exists := seenMsgMap[field.Type.Ref]; exists {
+		if _, exists := seenMsgMap[field.Type.Message]; exists {
 			continue
 		}
-		ret = append(ret, getGoPackageDependencies(base, field.Type.Ref, seenMsgMap)...)
+		ret = append(ret, getGoPackageDependencies(base, field.Type.Message, seenMsgMap)...)
 	}
 	for _, m := range msg.NestedMessages {
 		ret = append(ret, getGoPackageDependencies(base, m, seenMsgMap)...)

--- a/resolver/oneof.go
+++ b/resolver/oneof.go
@@ -17,12 +17,12 @@ func (oneof *Oneof) IsSameType() bool {
 		if prevType == nil {
 			prevType = fieldType
 		}
-		if prevType.Type != fieldType.Type {
+		if prevType.Kind != fieldType.Kind {
 			return false
 		}
-		switch fieldType.Type {
+		switch fieldType.Kind {
 		case types.Message:
-			if prevType.Ref != fieldType.Ref {
+			if prevType.Message != fieldType.Message {
 				return false
 			}
 		case types.Enum:

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mercari/grpc-federation/internal/testutil"
 	"github.com/mercari/grpc-federation/resolver"
 	"github.com/mercari/grpc-federation/source"
-	"github.com/mercari/grpc-federation/types"
 )
 
 func TestSimpleAggregation(t *testing.T) {
@@ -2414,9 +2413,9 @@ func TestConstValue(t *testing.T) {
 		content.Fields,
 		&resolver.Field{
 			Name: "message_field",
-			Type: &resolver.Type{Type: types.Message, Ref: content},
+			Type: resolver.NewMessageType(content, false),
 			Rule: testutil.NewFieldRuleBuilder(
-				testutil.NewMessageArgumentValueBuilder(&resolver.Type{Type: types.Message, Ref: content}, &resolver.Type{Type: types.Message, Ref: content}, "message_field").
+				testutil.NewMessageArgumentValueBuilder(resolver.NewMessageType(content, false), resolver.NewMessageType(content, false), "message_field").
 					Build(t),
 			).SetAlias(ref.Field(t, "content", "Content", "message_field")).Build(t),
 		},
@@ -2435,11 +2434,11 @@ func TestConstValue(t *testing.T) {
 		contentArg.Fields,
 		&resolver.Field{
 			Name: "message_field",
-			Type: &resolver.Type{Type: types.Message, Ref: content},
+			Type: resolver.NewMessageType(content, false),
 		},
 		&resolver.Field{
 			Name: "messages_field",
-			Type: &resolver.Type{Type: types.Message, Ref: content, Repeated: true},
+			Type: resolver.NewMessageType(content, true),
 		},
 	)
 

--- a/resolver/type_conversion.go
+++ b/resolver/type_conversion.go
@@ -14,7 +14,7 @@ func typeConversionDecls(fromType, toType *Type, convertedFQDNMap map[string]str
 	if fromType == nil || toType == nil {
 		return nil
 	}
-	if fromType.Type != toType.Type {
+	if fromType.Kind != toType.Kind {
 		return nil
 	}
 	if !requiredTypeConversion(fromType, toType) {
@@ -26,10 +26,10 @@ func typeConversionDecls(fromType, toType *Type, convertedFQDNMap map[string]str
 		return nil
 	}
 	convertedFQDNMap[fqdn] = struct{}{}
-	if fromType.Type == types.Message && fromType.Ref != nil && toType.Ref != nil && fromType.Ref.IsMapEntry {
+	if fromType.Kind == types.Message && fromType.Message != nil && toType.Message != nil && fromType.Message.IsMapEntry {
 		// map type
-		fromMap := fromType.Ref
-		toMap := toType.Ref
+		fromMap := fromType.Message
+		toMap := toType.Message
 		fromKey := fromMap.Field("key")
 		toKey := toMap.Field("key")
 		fromValue := fromMap.Field("value")
@@ -57,9 +57,9 @@ func typeConversionDecls(fromType, toType *Type, convertedFQDNMap map[string]str
 		ft.OneofField = nil
 		tt.OneofField = nil
 		decls = append(decls, typeConversionDecls(ft, tt, convertedFQDNMap)...)
-	case fromType.Type == types.Message:
-		for _, field := range toType.Ref.Fields {
-			fromField := fromType.Ref.Field(field.Name)
+	case fromType.Kind == types.Message:
+		for _, field := range toType.Message.Fields {
+			fromField := fromType.Message.Field(field.Name)
 			if fromField == nil {
 				continue
 			}
@@ -92,21 +92,21 @@ func requiredTypeConversion(fromType, toType *Type) bool {
 	if fromType == nil || toType == nil {
 		return false
 	}
-	if fromType.Type == types.Message {
-		if fromType.Ref.IsMapEntry {
-			fromKey := fromType.Ref.Field("key")
-			fromValue := fromType.Ref.Field("value")
-			toKey := toType.Ref.Field("key")
-			toValue := toType.Ref.Field("value")
+	if fromType.Kind == types.Message {
+		if fromType.Message.IsMapEntry {
+			fromKey := fromType.Message.Field("key")
+			fromValue := fromType.Message.Field("value")
+			toKey := toType.Message.Field("key")
+			toValue := toType.Message.Field("value")
 			if fromKey == nil || fromValue == nil || toKey == nil || toValue == nil {
 				return false
 			}
 			return requiredTypeConversion(fromKey.Type, toKey.Type) || requiredTypeConversion(fromValue.Type, toValue.Type)
 		}
-		return fromType.Ref != toType.Ref
+		return fromType.Message != toType.Message
 	}
-	if fromType.Type == types.Enum {
+	if fromType.Kind == types.Enum {
 		return fromType.Enum != toType.Enum
 	}
-	return fromType.Type != toType.Type
+	return fromType.Kind != toType.Kind
 }

--- a/resolver/types.go
+++ b/resolver/types.go
@@ -307,24 +307,25 @@ type FieldOneofRule struct {
 }
 
 type Type struct {
-	Type       types.Type
+	Kind       types.Kind
 	Repeated   bool
-	Ref        *Message
+	Message    *Message
 	Enum       *Enum
 	OneofField *OneofField
 }
 
 func (t *Type) Clone() *Type {
 	return &Type{
-		Type:     t.Type,
-		Repeated: t.Repeated,
-		Ref:      t.Ref,
-		Enum:     t.Enum,
+		Kind:       t.Kind,
+		Repeated:   t.Repeated,
+		Message:    t.Message,
+		Enum:       t.Enum,
+		OneofField: t.OneofField,
 	}
 }
 
 func (t *Type) IsNumber() bool {
-	switch t.Type {
+	switch t.Kind {
 	case types.Double,
 		types.Float,
 		types.Int64,
@@ -351,13 +352,13 @@ func (t *Type) FQDN() string {
 	if t.OneofField != nil {
 		return repeated + t.OneofField.FQDN()
 	}
-	if t.Ref != nil {
-		return repeated + t.Ref.FQDN()
+	if t.Message != nil {
+		return repeated + t.Message.FQDN()
 	}
 	if t.Enum != nil {
 		return repeated + t.Enum.FQDN()
 	}
-	return repeated + types.ToString(t.Type)
+	return repeated + types.ToString(t.Kind)
 }
 
 type MethodCall struct {
@@ -448,38 +449,38 @@ type ConstValue struct {
 type EnvKey string
 
 var (
-	DoubleType           = &Type{Type: types.Double}
-	FloatType            = &Type{Type: types.Float}
-	Int32Type            = &Type{Type: types.Int32}
-	Int64Type            = &Type{Type: types.Int64}
-	Uint32Type           = &Type{Type: types.Uint32}
-	Uint64Type           = &Type{Type: types.Uint64}
-	Sint32Type           = &Type{Type: types.Sint32}
-	Sint64Type           = &Type{Type: types.Sint64}
-	Fixed32Type          = &Type{Type: types.Fixed32}
-	Fixed64Type          = &Type{Type: types.Fixed64}
-	Sfixed32Type         = &Type{Type: types.Sfixed32}
-	Sfixed64Type         = &Type{Type: types.Sfixed64}
-	BoolType             = &Type{Type: types.Bool}
-	StringType           = &Type{Type: types.String}
-	BytesType            = &Type{Type: types.Bytes}
-	EnumType             = &Type{Type: types.Enum}
-	EnvType              = &Type{Type: types.String}
-	DoubleRepeatedType   = &Type{Type: types.Double, Repeated: true}
-	FloatRepeatedType    = &Type{Type: types.Float, Repeated: true}
-	Int32RepeatedType    = &Type{Type: types.Int32, Repeated: true}
-	Int64RepeatedType    = &Type{Type: types.Int64, Repeated: true}
-	Uint32RepeatedType   = &Type{Type: types.Uint32, Repeated: true}
-	Uint64RepeatedType   = &Type{Type: types.Uint64, Repeated: true}
-	Sint32RepeatedType   = &Type{Type: types.Sint32, Repeated: true}
-	Sint64RepeatedType   = &Type{Type: types.Sint64, Repeated: true}
-	Fixed32RepeatedType  = &Type{Type: types.Fixed32, Repeated: true}
-	Fixed64RepeatedType  = &Type{Type: types.Fixed64, Repeated: true}
-	Sfixed32RepeatedType = &Type{Type: types.Sfixed32, Repeated: true}
-	Sfixed64RepeatedType = &Type{Type: types.Sfixed64, Repeated: true}
-	BoolRepeatedType     = &Type{Type: types.Bool, Repeated: true}
-	StringRepeatedType   = &Type{Type: types.String, Repeated: true}
-	BytesRepeatedType    = &Type{Type: types.Bytes, Repeated: true}
-	EnumRepeatedType     = &Type{Type: types.Enum, Repeated: true}
-	EnvRepeatedType      = &Type{Type: types.String, Repeated: true}
+	DoubleType           = &Type{Kind: types.Double}
+	FloatType            = &Type{Kind: types.Float}
+	Int32Type            = &Type{Kind: types.Int32}
+	Int64Type            = &Type{Kind: types.Int64}
+	Uint32Type           = &Type{Kind: types.Uint32}
+	Uint64Type           = &Type{Kind: types.Uint64}
+	Sint32Type           = &Type{Kind: types.Sint32}
+	Sint64Type           = &Type{Kind: types.Sint64}
+	Fixed32Type          = &Type{Kind: types.Fixed32}
+	Fixed64Type          = &Type{Kind: types.Fixed64}
+	Sfixed32Type         = &Type{Kind: types.Sfixed32}
+	Sfixed64Type         = &Type{Kind: types.Sfixed64}
+	BoolType             = &Type{Kind: types.Bool}
+	StringType           = &Type{Kind: types.String}
+	BytesType            = &Type{Kind: types.Bytes}
+	EnumType             = &Type{Kind: types.Enum}
+	EnvType              = &Type{Kind: types.String}
+	DoubleRepeatedType   = &Type{Kind: types.Double, Repeated: true}
+	FloatRepeatedType    = &Type{Kind: types.Float, Repeated: true}
+	Int32RepeatedType    = &Type{Kind: types.Int32, Repeated: true}
+	Int64RepeatedType    = &Type{Kind: types.Int64, Repeated: true}
+	Uint32RepeatedType   = &Type{Kind: types.Uint32, Repeated: true}
+	Uint64RepeatedType   = &Type{Kind: types.Uint64, Repeated: true}
+	Sint32RepeatedType   = &Type{Kind: types.Sint32, Repeated: true}
+	Sint64RepeatedType   = &Type{Kind: types.Sint64, Repeated: true}
+	Fixed32RepeatedType  = &Type{Kind: types.Fixed32, Repeated: true}
+	Fixed64RepeatedType  = &Type{Kind: types.Fixed64, Repeated: true}
+	Sfixed32RepeatedType = &Type{Kind: types.Sfixed32, Repeated: true}
+	Sfixed64RepeatedType = &Type{Kind: types.Sfixed64, Repeated: true}
+	BoolRepeatedType     = &Type{Kind: types.Bool, Repeated: true}
+	StringRepeatedType   = &Type{Kind: types.String, Repeated: true}
+	BytesRepeatedType    = &Type{Kind: types.Bytes, Repeated: true}
+	EnumRepeatedType     = &Type{Kind: types.Enum, Repeated: true}
+	EnvRepeatedType      = &Type{Kind: types.String, Repeated: true}
 )

--- a/resolver/value.go
+++ b/resolver/value.go
@@ -678,7 +678,7 @@ func NewEnumValue(v *EnumValue) *Value {
 	return &Value{
 		Const: &ConstValue{
 			Type: &Type{
-				Type: types.Enum,
+				Kind: types.Enum,
 				Enum: enum,
 			},
 			Value: v,
@@ -694,7 +694,7 @@ func NewEnumsValue(v ...*EnumValue) *Value {
 	return &Value{
 		Const: &ConstValue{
 			Type: &Type{
-				Type:     types.Enum,
+				Kind:     types.Enum,
 				Enum:     enum,
 				Repeated: true,
 			},

--- a/resolver/wellknown_types.go
+++ b/resolver/wellknown_types.go
@@ -1,9 +1,5 @@
 package resolver
 
-import (
-	"github.com/mercari/grpc-federation/types"
-)
-
 var (
 	AnyType       *Type
 	TimestampType *Type
@@ -18,16 +14,16 @@ func init() {
 	}
 	for _, file := range files.FindByPackageName("google.protobuf") {
 		if msg := file.Message("Any"); msg != nil {
-			AnyType = &Type{Type: types.Message, Ref: msg}
+			AnyType = NewMessageType(msg, false)
 		}
 		if msg := file.Message("Timestamp"); msg != nil {
-			TimestampType = &Type{Type: types.Message, Ref: msg}
+			TimestampType = NewMessageType(msg, false)
 		}
 		if msg := file.Message("Duration"); msg != nil {
-			DurationType = &Type{Type: types.Message, Ref: msg}
+			DurationType = NewMessageType(msg, false)
 		}
 		if msg := file.Message("Empty"); msg != nil {
-			EmptyType = &Type{Type: types.Message, Ref: msg}
+			EmptyType = NewMessageType(msg, false)
 		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -2,7 +2,7 @@ package types
 
 import "google.golang.org/protobuf/types/descriptorpb"
 
-type Type = descriptorpb.FieldDescriptorProto_Type
+type Kind = descriptorpb.FieldDescriptorProto_Type
 
 var (
 	Double   = descriptorpb.FieldDescriptorProto_TYPE_DOUBLE
@@ -25,8 +25,8 @@ var (
 	Sint64   = descriptorpb.FieldDescriptorProto_TYPE_SINT64
 )
 
-func ToString(t Type) string {
-	switch t {
+func ToString(kind Kind) string {
+	switch kind {
 	case Double:
 		return "double"
 	case Float:


### PR DESCRIPTION
To make the source code more understandable, rename the following fields

- `types.Type` => `types.Kind`
- `resolver.Type.Type` => `resolver.Type.Kind`
- `resolver.Type.Ref` => `resolver.Type.Message`