### PR TITLE
Fix import errors

### DIFF
--- a/generator/code_generator.go
+++ b/generator/code_generator.go
@@ -320,7 +320,7 @@ func (f *File) StandardImports() []*Import {
 	}
 
 	pkgs := []*Import{
-		{Path: "context", Used: true},
+		{Path: "context", Used: existsServiceDef || existsPluginDef},
 		{Path: "encoding/json", Used: existsPluginDef},
 		{Path: "io", Used: existsServiceDef},
 		{Path: "log/slog", Used: existsServiceDef},
@@ -349,7 +349,7 @@ func (f *File) DefaultImports() []*Import {
 		existsPluginDef = true
 	}
 	pkgs := []*Import{
-		{Alias: "grpcfed", Path: "github.com/mercari/grpc-federation/grpc/federation", Used: true},
+		{Alias: "grpcfed", Path: "github.com/mercari/grpc-federation/grpc/federation", Used: existsServiceDef || existsPluginDef},
 		{Alias: "grpcfedcel", Path: "github.com/mercari/grpc-federation/grpc/federation/cel", Used: existsServiceDef},
 		{Path: "go.opentelemetry.io/otel", Used: existsServiceDef},
 		{Path: "go.opentelemetry.io/otel/trace", Used: existsServiceDef},

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -560,6 +560,9 @@ func (g *Generator) generateByProtogenGoGRPC(r *PluginRequest) (*pluginpb.CodeGe
 			continue
 		}
 		generatedFile := runProtogenGoGRPC(r.genplugin, f, true)
+		if generatedFile == nil {
+			continue
+		}
 		content, err := generatedFile.Content()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I've tackled the following two problems:

1. `context` and `grpcfed` libraries are imported unnecessarily even if a proto file does not contain any service or plugin definitions.
2.  `generateByProtogenGoGRPC` panics when running against a file that does not contain any service definitions.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1013506b4]

goroutine 1 [running]:
google.golang.org/protobuf/compiler/protogen.(*GeneratedFile).Content(0x0)
	/Users/shuheiktgw/go/1.22.0/pkg/mod/google.golang.org/protobuf@v1.32.0/compiler/protogen/protogen.go:1045 +0x24
github.com/mercari/grpc-federation/generator.(*Generator).generateByProtogenGoGRPC(0x1400033c000, 0x14001011170)
	/Users/shuheiktgw/go/1.22.0/pkg/mod/github.com/mercari/grpc-federation@v0.13.1/generator/generator.go:563 +0x16c
github.com/mercari/grpc-federation/generator.(*Generator).generateByPlugin(0x1400033c000, {0x101b14ac0?, 0x1025340e0?}, 0x14001011170, 0x1400035c5a0)
	/Users/shuheiktgw/go/1.22.0/pkg/mod/github.com/mercari/grpc-federation@v0.13.1/generator/generator.go:267 +0x15c
```
