### PR TITLE
Use f.File.Enums instead of f.enums for import

### DIFF
--- a/generator/code_generator.go
+++ b/generator/code_generator.go
@@ -412,7 +412,7 @@ func (f *File) Imports() []*Import {
 			depMap[dep.ImportPath] = dep
 		}
 	}
-	for _, enum := range f.enums {
+	for _, enum := range f.File.Enums {
 		protoName := enum.FQDN()
 		// ignore standard library's enum.
 		if strings.HasPrefix(protoName, "google.") {


### PR DESCRIPTION
We should have used `f.File.Enums` instead of `f.enums` since `f.enums` contain all the nums defined in the package.