### PR TITLE
Skip if the candidates' file name matches unexpectedly

### DIFF
--- a/resolver/candidates.go
+++ b/resolver/candidates.go
@@ -77,7 +77,11 @@ func (r *Resolver) Candidates(loc *source.Location) []string {
 			protoPkgName := file.GetPackage()
 			switch {
 			case loc.Message != nil:
-				msg := r.cachedMessageMap[fmt.Sprintf("%s.%s", protoPkgName, loc.Message.Name)]
+				msg, ok := r.cachedMessageMap[fmt.Sprintf("%s.%s", protoPkgName, loc.Message.Name)]
+				if !ok {
+					// The file name could match wrongly if it has the same suffix
+					continue
+				}
 				return r.candidatesMessage(msg, loc.Message)
 			case loc.Service != nil:
 			}

--- a/resolver/candidates_test.go
+++ b/resolver/candidates_test.go
@@ -52,6 +52,10 @@ func TestCandidates(t *testing.T) {
 	r := &Resolver{
 		files: []*descriptorpb.FileDescriptorProto{
 			{
+				Name:    proto.String("another/foo.proto"),
+				Package: proto.String("anotherfoo"),
+			},
+			{
 				Name:    proto.String("foo.proto"),
 				Package: proto.String("foo"),
 			},


### PR DESCRIPTION
The comment and the test explain it all, but Resolver#Candidates could panic if the file name suffix matches unexpectedly since `r.cachedMessageMap[fmt.Sprintf("%s.%s", protoPkgName, loc.Message.Name)]` returns nil in that case. 