### PR TITLE
Fix cel plugin function for enum type

### DIFF
--- a/resolver/cel.go
+++ b/resolver/cel.go
@@ -175,14 +175,14 @@ func (f *CELFunction) signatures(args []*Type, ret *Type) []*CELPluginFunctionSi
 		if arg.Kind == types.Enum {
 			sigs = append(sigs,
 				f.signatures(
-					append(append(append([]*Type{}, args[:idx]...), &Type{Kind: types.Int32}), args[idx+1:]...),
+					append(append(append([]*Type{}, args[:idx]...), Int32Type), args[idx+1:]...),
 					ret,
 				)...,
 			)
 		}
 	}
 	if ret.Kind == types.Enum {
-		sigs = append(sigs, f.signatures(args, &Type{Kind: types.Int32})...)
+		sigs = append(sigs, f.signatures(args, Int32Type)...)
 	}
 	var celArgs []*cel.Type
 	for _, arg := range args {

--- a/resolver/cel.go
+++ b/resolver/cel.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
@@ -146,16 +147,64 @@ func (plugin *CELPlugin) LibraryName() string {
 	return plugin.Name
 }
 
-func (f *CELFunction) CELArgs() []*cel.Type {
-	ret := make([]*cel.Type, 0, len(f.Args))
-	for _, arg := range f.Args {
-		ret = append(ret, ToCELType(arg))
+type CELPluginFunctionSignature struct {
+	ID     string
+	Args   []*cel.Type
+	Return *cel.Type
+}
+
+// Signatures returns signature for overload function.
+// If there is an enum type, we need to prepare functions for both `opaque<int>` and `int` patterns.
+func (f *CELFunction) Signatures() []*CELPluginFunctionSignature {
+	sigs := f.signatures(f.Args, f.Return)
+	sigMap := make(map[string]struct{})
+	ret := make([]*CELPluginFunctionSignature, 0, len(sigs))
+	for _, sig := range sigs {
+		if _, exists := sigMap[sig.ID]; exists {
+			continue
+		}
+		ret = append(ret, sig)
+		sigMap[sig.ID] = struct{}{}
 	}
 	return ret
 }
 
-func (f *CELFunction) CELReturn() *cel.Type {
-	return ToCELType(f.Return)
+func (f *CELFunction) signatures(args []*Type, ret *Type) []*CELPluginFunctionSignature {
+	var sigs []*CELPluginFunctionSignature
+	for idx, arg := range args {
+		if arg.Kind == types.Enum {
+			sigs = append(sigs,
+				f.signatures(
+					append(append(append([]*Type{}, args[:idx]...), &Type{Kind: types.Int32}), args[idx+1:]...),
+					ret,
+				)...,
+			)
+		}
+	}
+	if ret.Kind == types.Enum {
+		sigs = append(sigs, f.signatures(args, &Type{Kind: types.Int32})...)
+	}
+	var celArgs []*cel.Type
+	for _, arg := range args {
+		celArgs = append(celArgs, ToCELType(arg))
+	}
+	sigs = append(sigs, &CELPluginFunctionSignature{
+		ID:     f.toSignatureID(append(args, ret)),
+		Args:   celArgs,
+		Return: toCELType(ret),
+	})
+	return sigs
+}
+
+func (f *CELFunction) toSignatureID(t []*Type) string {
+	var typeNames []string
+	for _, tt := range t {
+		if tt == nil {
+			continue
+		}
+		typeNames = append(typeNames, tt.FQDN())
+	}
+	return strings.ReplaceAll(strings.Join(append([]string{f.ID}, typeNames...), "_"), ".", "_")
 }
 
 func (plugin *CELPlugin) CompileOptions() []cel.EnvOption {
@@ -165,12 +214,14 @@ func (plugin *CELPlugin) CompileOptions() []cel.EnvOption {
 			overload cel.FunctionOpt
 			bindFunc = cel.FunctionBinding(func(args ...ref.Val) ref.Val { return nil })
 		)
-		if fn.Receiver != nil {
-			overload = cel.MemberOverload(fn.ID, fn.CELArgs(), fn.CELReturn(), bindFunc)
-		} else {
-			overload = cel.Overload(fn.ID, fn.CELArgs(), fn.CELReturn(), bindFunc)
+		for _, sig := range fn.Signatures() {
+			if fn.Receiver != nil {
+				overload = cel.MemberOverload(sig.ID, sig.Args, sig.Return, bindFunc)
+			} else {
+				overload = cel.Overload(sig.ID, sig.Args, sig.Return, bindFunc)
+			}
+			opts = append(opts, cel.Function(fn.Name, overload))
 		}
-		opts = append(opts, cel.Function(fn.Name, overload))
 	}
 	return opts
 }

--- a/resolver/cel_test.go
+++ b/resolver/cel_test.go
@@ -1,0 +1,74 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/mercari/grpc-federation/resolver"
+	"github.com/mercari/grpc-federation/types"
+)
+
+func TestCELFunction(t *testing.T) {
+	enumType := &resolver.Type{
+		Kind: types.Enum,
+		Enum: &resolver.Enum{
+			File: &resolver.File{},
+			Name: "EnumType",
+		},
+	}
+	celEnumType := celtypes.NewOpaqueType(enumType.Enum.FQDN(), cel.IntType)
+	fn := resolver.CELFunction{
+		Name:   "test",
+		ID:     "test",
+		Args:   []*resolver.Type{enumType, enumType},
+		Return: enumType,
+	}
+	if diff := cmp.Diff(fn.Signatures(), []*resolver.CELPluginFunctionSignature{
+		{
+			ID:     "test_int32_int32_int32",
+			Args:   []*cel.Type{cel.IntType, cel.IntType},
+			Return: cel.IntType,
+		},
+		{
+			ID:     "test_int32_int32__EnumType",
+			Args:   []*cel.Type{cel.IntType, cel.IntType},
+			Return: celEnumType,
+		},
+		{
+			ID:     "test_int32__EnumType_int32",
+			Args:   []*cel.Type{cel.IntType, celEnumType},
+			Return: cel.IntType,
+		},
+		{
+			ID:     "test_int32__EnumType__EnumType",
+			Args:   []*cel.Type{cel.IntType, celEnumType},
+			Return: celEnumType,
+		},
+		{
+			ID:     "test__EnumType_int32_int32",
+			Args:   []*cel.Type{celEnumType, cel.IntType},
+			Return: cel.IntType,
+		},
+		{
+			ID:     "test__EnumType_int32__EnumType",
+			Args:   []*cel.Type{celEnumType, cel.IntType},
+			Return: celEnumType,
+		},
+		{
+			ID:     "test__EnumType__EnumType_int32",
+			Args:   []*cel.Type{celEnumType, celEnumType},
+			Return: cel.IntType,
+		},
+		{
+			ID:     "test__EnumType__EnumType__EnumType",
+			Args:   []*cel.Type{celEnumType, celEnumType},
+			Return: celEnumType,
+		},
+	}, cmpopts.IgnoreUnexported(cel.Type{})); diff != "" {
+		t.Errorf("(-got, +want)\n%s", diff)
+	}
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -461,8 +461,15 @@ func (r *Resolver) resolvePluginFunctionType(ctx *context, typeName string, repe
 	}
 	kind := types.ToKind(typeName)
 	if kind == types.Unknown {
-		// TODO: do not consider enums at first.
-		kind = types.Message
+		// we want to avoid capturing errors when calling resolveType, so create a new context to bypass it.
+		ctx := newContext().withFile(ctx.file())
+		if typ, err := r.resolveType(ctx, typeName, types.Message, label); err == nil && typ.Message != nil {
+			return typ, nil
+		}
+		if typ, err := r.resolveType(ctx, typeName, types.Enum, label); err == nil && typ.Enum != nil {
+			return typ, nil
+		}
+		return nil, fmt.Errorf("unexpected type %s", typeName)
 	}
 	return r.resolveType(ctx, typeName, kind, label)
 }


### PR DESCRIPTION
Enable specifying an enum type for plugin functions as follows

```
enum EnumType {
  ENUM_FOO = 0;
  ENUM_BAR = 1;
}

option (grpc.federation.plugin).export = {
  name : "plugin"
  functions {name : "example" args {name : "v" type : "EnumType"} return {type : "bool"}}
};

```