### PR TITLE
Fix message argument type conversion

### DIFF
--- a/resolver/format_test.go
+++ b/resolver/format_test.go
@@ -67,6 +67,10 @@ func TestProtoFormat(t *testing.T) {
       autobind: true
       message {
         name: "M"
+        args: [
+          { name: "x", by: "10" },
+          { name: "y", by: "1" }
+        ]
       }
     }
   }`,
@@ -89,6 +93,16 @@ func TestProtoFormat(t *testing.T) {
       name: "user"
       autobind: true
       by: "res.user"
+    }
+    def {
+      name: "_def2"
+      message {
+        name: "M"
+        args: [
+          { name: "x", by: "uint(2)" },
+          { name: "y", by: "org.user.Item.ItemType.value('ITEM_TYPE_2')" }
+        ]
+      }
     }
   }`,
 			},

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -68,6 +68,8 @@ func TestSimpleAggregation(t *testing.T) {
 		).
 		AddMessage(
 			testutil.NewMessageBuilder("MArgument").
+				AddField("x", resolver.Uint64Type).
+				AddField("y", ref.Type(t, "org.user", "Item.ItemType")).
 				Build(t),
 		).
 		AddMessage(
@@ -193,12 +195,31 @@ func TestSimpleAggregation(t *testing.T) {
 								SetBy(testutil.NewCELValueBuilder("res.user", ref.Type(t, "org.user", "User")).Build(t)).
 								Build(t),
 						).
+						AddVariableDefinition(
+							testutil.NewVariableDefinitionBuilder().
+								SetName("_def2").
+								SetUsed(true).
+								SetMessage(
+									testutil.NewMessageExprBuilder().
+										SetMessage(ref.Message(t, "org.federation", "M")).
+										SetArgs(
+											testutil.NewMessageDependencyArgumentBuilder().
+												Add("x", resolver.NewByValue("uint(2)", resolver.Uint64Type)).
+												Add("y", resolver.NewByValue("org.user.Item.ItemType.value('ITEM_TYPE_2')", ref.Type(t, "org.user", "Item.ItemType"))).
+												Build(t),
+										).
+										Build(t),
+								).
+								Build(t),
+						).
 						SetMessageArgument(ref.Message(t, "org.federation", "UserArgument")).
 						SetDependencyGraph(
 							testutil.NewDependencyGraphBuilder().
+								Add(ref.Message(t, "org.federation", "M")).
 								Add(ref.Message(t, "org.user", "GetUserResponse")).
 								Build(t),
 						).
+						AddVariableDefinitionGroup(testutil.NewVariableDefinitionGroupByName("_def2")).
 						AddVariableDefinitionGroup(
 							testutil.NewVariableDefinitionGroupBuilder().
 								AddStart(testutil.NewVariableDefinitionGroupByName("res")).
@@ -295,6 +316,12 @@ func TestSimpleAggregation(t *testing.T) {
 								SetMessage(
 									testutil.NewMessageExprBuilder().
 										SetMessage(ref.Message(t, "org.federation", "M")).
+										SetArgs(
+											testutil.NewMessageDependencyArgumentBuilder().
+												Add("x", resolver.NewByValue("10", resolver.Int64Type)).
+												Add("y", resolver.NewByValue("1", resolver.Int64Type)).
+												Build(t),
+										).
 										Build(t),
 								).
 								Build(t),

--- a/testdata/simple_aggregation.proto
+++ b/testdata/simple_aggregation.proto
@@ -58,7 +58,17 @@ message Post {
       { name: "post" by: "res.post" autobind: true },
       { name: "user" message { name: "User" args { inline: "post" } } },
       { name: "z" message { name: "Z" } },
-      { name: "m" message { name: "M" } autobind: true}
+      {
+        name: "m"
+        message {
+          name: "M"
+          args [
+            { name: "x" by: "10" },
+            { name: "y" by: "1" }
+          ]
+        }
+        autobind: true
+      }
     ]
   };
   string id = 1;
@@ -97,6 +107,15 @@ message User {
       }
     }
     def { name: "user" by: "res.user" autobind: true }
+    def {
+      message {
+        name: "M"
+        args [
+          { name: "x" by: "uint(2)" },
+          { name: "y" by: "org.user.Item.ItemType.value('ITEM_TYPE_2')" }
+        ]
+      }
+    }
   };
   string id = 1;
   UserType type = 2;

--- a/validator/testdata/invalid_message_argument.proto
+++ b/validator/testdata/invalid_message_argument.proto
@@ -11,6 +11,8 @@ option go_package = "example/federation;federation";
 service FederationService {
   option (grpc.federation.service) = {};
   rpc GetPost(GetPostRequest) returns (GetPostResponse) {};
+  rpc Foo(FooRequest) returns (FooResponse) {}
+  rpc Bar(BarRequest) returns (BarResponse) {}
 }
 
 message GetPostRequest {
@@ -74,4 +76,37 @@ message User {
   };
   string id = 1;
   string name = 2;
+}
+
+message FooRequest {}
+message FooResponse {
+  option (grpc.federation.message) = {
+    def {
+      message {
+        name: "M"
+        args { name: "x" by: "true" }
+      }
+      autobind: true
+    }
+  };
+  string x = 1;
+}
+
+
+message BarRequest {}
+message BarResponse {
+  option (grpc.federation.message) = {
+    def {
+      message {
+        name: "M"
+        args { name: "x" by: "'foo'" }
+      }
+      autobind: true
+    }
+  };
+  string x = 1;
+}
+
+message M {
+  string x = 1 [(grpc.federation.field).by = "'hello'"];
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -450,29 +450,32 @@ testdata/invalid_nested_message_name.proto:47:49: unknown type null_type is requ
                                                      ^
 `},
 		{file: "invalid_message_argument.proto", expected: `
-testdata/invalid_message_argument.proto:49:19: ERROR: <input>:1:11: type 'string' does not support field selection
+testdata/invalid_message_argument.proto:51:19: ERROR: <input>:1:11: type 'string' does not support field selection
  | __ARG__.id.invalid
  | ..........^
-49:              { by: "$.id.invalid" },
+51:              { by: "$.id.invalid" },
                        ^
-testdata/invalid_message_argument.proto:50:23: inline value is not message type
-50:              { inline: "post.id" },
+testdata/invalid_message_argument.proto:52:23: inline value is not message type
+52:              { inline: "post.id" },
                            ^
-testdata/invalid_message_argument.proto:51:19: ERROR: <input>:1:2: Syntax error: no viable alternative at input '..'
+testdata/invalid_message_argument.proto:53:19: ERROR: <input>:1:2: Syntax error: no viable alternative at input '..'
  | ....
  | .^
-51:              { by: "...." },
+53:              { by: "...." },
                        ^
-testdata/invalid_message_argument.proto:52:23: ERROR: <input>:1:2: Syntax error: no viable alternative at input '..'
+testdata/invalid_message_argument.proto:54:23: ERROR: <input>:1:2: Syntax error: no viable alternative at input '..'
  | ....
  | .^
-52:              { inline: "...." }
+54:              { inline: "...." }
                            ^
-testdata/invalid_message_argument.proto:70:36: ERROR: <input>:1:8: undefined field 'user_id'
+testdata/invalid_message_argument.proto:72:36: ERROR: <input>:1:8: undefined field 'user_id'
  | __ARG__.user_id
  | .......^
-70:          request { field: "id", by: "$.user_id" }
+72:          request { field: "id", by: "$.user_id" }
                                         ^
+testdata/invalid_message_argument.proto:87:14: "x" argument name is declared with a different type kind. found "string" and "bool" type
+87:          args { name: "x" by: "true" }
+                  ^
 `},
 		{file: "invalid_message_field_alias.proto", expected: `
 testdata/invalid_message_field_alias.proto:59:3: The types of "org.federation.PostData"'s "title" field ("int64") and "org.post.PostData"'s field ("string") are different. This field cannot be resolved automatically, so you must use the "grpc.federation.field" option to bind it yourself


### PR DESCRIPTION
For numeric types, the specification allows accepting them even if the type of the message argument differs. In such cases, since the actual message argument type may differ, additional type conversion is necessary.