### PR TITLE
Fix presence detection of field's type value

### DIFF
--- a/grpc/federation/cel.go
+++ b/grpc/federation/cel.go
@@ -119,7 +119,7 @@ func NewCELFieldType(typ *celtypes.Type, fieldName string) *celtypes.FieldType {
 		if rv.Kind() != reflect.Struct {
 			return false
 		}
-		return rv.FieldByName(fieldName).IsValid()
+		return !rv.FieldByName(fieldName).IsZero()
 	}
 	getFrom := func(v any, fieldName string) (any, error) {
 		rv := reflect.ValueOf(v)


### PR DESCRIPTION
In message argument types, there are cases where has(e.f) should be false but is true.
I think we need to check if the value is a zero value when detecting the presence of field type value.