### PR TITLE
Fix logger propaggation

### DIFF
--- a/_examples/01_minimum/federation/federation_grpc_federation.pb.go
+++ b/_examples/01_minimum/federation/federation_grpc_federation.pb.go
@@ -157,6 +157,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetPostResponse", slog.Any("message_args", s.logvalue_Federation_GetPostResponseArgument(req)))
 

--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -265,6 +265,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Federation_AArgument) (*A, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.A")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.A", slog.Any("message_args", s.logvalue_Federation_AArgument(req)))
 	type localValueType struct {
@@ -335,6 +336,7 @@ func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Feder
 func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Federation_A_BArgument) (*A_B, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.A.B")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.A.B", slog.Any("message_args", s.logvalue_Federation_A_BArgument(req)))
 	type localValueType struct {
@@ -644,6 +646,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 func (s *FederationService) resolve_Federation_A_B_C(ctx context.Context, req *Federation_A_B_CArgument) (*A_B_C, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.A.B.C")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.A.B.C", slog.Any("message_args", s.logvalue_Federation_A_B_CArgument(req)))
 	type localValueType struct {
@@ -685,6 +688,7 @@ func (s *FederationService) resolve_Federation_A_B_C(ctx context.Context, req *F
 func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetPostResponse", slog.Any("message_args", s.logvalue_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -1582,6 +1586,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Post", slog.Any("message_args", s.logvalue_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -1755,6 +1760,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.User", slog.Any("message_args", s.logvalue_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -326,6 +326,7 @@ func (s *FederationV2DevService) GetPostV2Dev(ctx context.Context, req *GetPostV
 func (s *FederationV2DevService) resolve_Federation_V2Dev_ForNameless(ctx context.Context, req *Federation_V2Dev_ForNamelessArgument) (*ForNameless, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.ForNameless")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.v2dev.ForNameless", slog.Any("message_args", s.logvalue_Federation_V2Dev_ForNamelessArgument(req)))
 
@@ -346,6 +347,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_ForNameless(ctx contex
 func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(ctx context.Context, req *Federation_V2Dev_GetPostV2DevResponseArgument) (*GetPostV2DevResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.GetPostV2devResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.v2dev.GetPostV2devResponse", slog.Any("message_args", s.logvalue_Federation_V2Dev_GetPostV2DevResponseArgument(req)))
 	type localValueType struct {
@@ -550,6 +552,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(c
 func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.Context, req *Federation_V2Dev_PostV2DevArgument) (*PostV2Dev, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.PostV2dev")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.v2dev.PostV2dev", slog.Any("message_args", s.logvalue_Federation_V2Dev_PostV2DevArgument(req)))
 	type localValueType struct {
@@ -815,6 +818,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 func (s *FederationV2DevService) resolve_Federation_V2Dev_Ref(ctx context.Context, req *Federation_V2Dev_RefArgument) (*Ref, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.Ref")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.v2dev.Ref", slog.Any("message_args", s.logvalue_Federation_V2Dev_RefArgument(req)))
 	type localValueType struct {
@@ -857,6 +861,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_Ref(ctx context.Contex
 func (s *FederationV2DevService) resolve_Federation_V2Dev_Unused(ctx context.Context, req *Federation_V2Dev_UnusedArgument) (*Unused, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.Unused")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.v2dev.Unused", slog.Any("message_args", s.logvalue_Federation_V2Dev_UnusedArgument(req)))
 
@@ -877,6 +882,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_Unused(ctx context.Con
 func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Context, req *Federation_V2Dev_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.v2dev.User", slog.Any("message_args", s.logvalue_Federation_V2Dev_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -176,6 +176,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetPostResponse", slog.Any("message_args", s.logvalue_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -260,6 +261,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Post", slog.Any("message_args", s.logvalue_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/_examples/05_async/federation/federation_grpc_federation.pb.go
+++ b/_examples/05_async/federation/federation_grpc_federation.pb.go
@@ -231,6 +231,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *Org_Federation_AArgument) (*A, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.A")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.A", slog.Any("message_args", s.logvalue_Org_Federation_AArgument(req)))
 	type localValueType struct {
@@ -342,6 +343,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *Org_Federation_AAArgument) (*AA, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AA")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.AA", slog.Any("message_args", s.logvalue_Org_Federation_AAArgument(req)))
 	type localValueType struct {
@@ -383,6 +385,7 @@ func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *
 func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *Org_Federation_ABArgument) (*AB, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AB")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.AB", slog.Any("message_args", s.logvalue_Org_Federation_ABArgument(req)))
 	type localValueType struct {
@@ -424,6 +427,7 @@ func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *
 func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *Org_Federation_BArgument) (*B, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.B")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.B", slog.Any("message_args", s.logvalue_Org_Federation_BArgument(req)))
 	type localValueType struct {
@@ -465,6 +469,7 @@ func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *Org_Federation_CArgument) (*C, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.C")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.C", slog.Any("message_args", s.logvalue_Org_Federation_CArgument(req)))
 	type localValueType struct {
@@ -506,6 +511,7 @@ func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *Org_Federation_DArgument) (*D, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.D")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.D", slog.Any("message_args", s.logvalue_Org_Federation_DArgument(req)))
 	type localValueType struct {
@@ -547,6 +553,7 @@ func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *Org_Federation_EArgument) (*E, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.E")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.E", slog.Any("message_args", s.logvalue_Org_Federation_EArgument(req)))
 	type localValueType struct {
@@ -588,6 +595,7 @@ func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *Org_Federation_FArgument) (*F, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.F")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.F", slog.Any("message_args", s.logvalue_Org_Federation_FArgument(req)))
 	type localValueType struct {
@@ -629,6 +637,7 @@ func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *Org_Federation_GArgument) (*G, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.G")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.G", slog.Any("message_args", s.logvalue_Org_Federation_GArgument(req)))
 	type localValueType struct {
@@ -670,6 +679,7 @@ func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -1334,6 +1344,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *Org_Federation_HArgument) (*H, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.H")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.H", slog.Any("message_args", s.logvalue_Org_Federation_HArgument(req)))
 	type localValueType struct {
@@ -1375,6 +1386,7 @@ func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *Org_Federation_IArgument) (*I, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.I")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.I", slog.Any("message_args", s.logvalue_Org_Federation_IArgument(req)))
 	type localValueType struct {
@@ -1416,6 +1428,7 @@ func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *Org_Federation_JArgument) (*J, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.J")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.J", slog.Any("message_args", s.logvalue_Org_Federation_JArgument(req)))
 	type localValueType struct {

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -222,6 +222,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -336,6 +337,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -183,6 +183,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -258,6 +259,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -421,6 +423,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -171,6 +171,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -213,6 +213,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -424,6 +425,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req *Org_Federation_SubArgument) (*Sub, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Sub")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Sub", slog.Any("message_args", s.logvalue_Org_Federation_SubArgument(req)))
 
@@ -444,6 +446,7 @@ func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req 
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {
@@ -601,6 +604,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, req *Org_Federation_UserIDArgument) (*UserID, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserID")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.UserID", slog.Any("message_args", s.logvalue_Org_Federation_UserIDArgument(req)))
 	type localValueType struct {

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -208,6 +208,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -351,6 +352,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 func (s *FederationService) resolve_Org_Federation_MessageSelection(ctx context.Context, req *Org_Federation_MessageSelectionArgument) (*MessageSelection, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.MessageSelection")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.MessageSelection", slog.Any("message_args", s.logvalue_Org_Federation_MessageSelectionArgument(req)))
 	type localValueType struct {
@@ -447,6 +449,7 @@ func (s *FederationService) resolve_Org_Federation_MessageSelection(ctx context.
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {
@@ -581,6 +584,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Context, req *Org_Federation_UserSelectionArgument) (*UserSelection, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserSelection")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.UserSelection", slog.Any("message_args", s.logvalue_Org_Federation_UserSelectionArgument(req)))
 	type localValueType struct {

--- a/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
@@ -177,6 +177,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetPostResponse", slog.Any("message_args", s.logvalue_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -247,6 +248,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Post", slog.Any("message_args", s.logvalue_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -571,6 +573,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req *Federation_ReactionArgument) (*Reaction, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Reaction")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Reaction", slog.Any("message_args", s.logvalue_Federation_ReactionArgument(req)))
 	type localValueType struct {
@@ -666,6 +669,7 @@ func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req
 func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.User", slog.Any("message_args", s.logvalue_Federation_UserArgument(req)))
 	type localValueType struct {
@@ -955,6 +959,7 @@ func (s *DebugService) GetStatus(ctx context.Context, req *GetStatusRequest) (re
 func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context, req *Federation_GetStatusResponseArgument) (*GetStatusResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetStatusResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetStatusResponse", slog.Any("message_args", s.logvalue_Federation_GetStatusResponseArgument(req)))
 	type localValueType struct {
@@ -1055,6 +1060,7 @@ func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context,
 func (s *DebugService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.User", slog.Any("message_args", s.logvalue_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/11_multi_service/federation/other_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/other_grpc_federation.pb.go
@@ -180,6 +180,7 @@ func (s *OtherService) Get(ctx context.Context, req *GetRequest) (res *GetRespon
 func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetResponse", slog.Any("message_args", s.logvalue_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -248,6 +249,7 @@ func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *
 func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Post", slog.Any("message_args", s.logvalue_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -572,6 +574,7 @@ func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *Federat
 func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *Federation_ReactionArgument) (*Reaction, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Reaction")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Reaction", slog.Any("message_args", s.logvalue_Federation_ReactionArgument(req)))
 	type localValueType struct {
@@ -667,6 +670,7 @@ func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *Fed
 func (s *OtherService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.User", slog.Any("message_args", s.logvalue_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/12_validation/federation/federation_grpc_federation.pb.go
+++ b/_examples/12_validation/federation/federation_grpc_federation.pb.go
@@ -182,6 +182,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_CustomHandlerMessage(ctx context.Context, req *Org_Federation_CustomHandlerMessageArgument) (*CustomHandlerMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomHandlerMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CustomHandlerMessage", slog.Any("message_args", s.logvalue_Org_Federation_CustomHandlerMessageArgument(req)))
 	type localValueType struct {
@@ -255,6 +256,7 @@ func (s *FederationService) resolve_Org_Federation_CustomHandlerMessage(ctx cont
 func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CustomMessage", slog.Any("message_args", s.logvalue_Org_Federation_CustomMessageArgument(req)))
 	type localValueType struct {
@@ -296,6 +298,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -945,6 +948,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -208,6 +208,7 @@ func (s *FederationService) GetPosts(ctx context.Context, req *GetPostsRequest) 
 func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.Context, req *Org_Federation_GetPostsResponseArgument) (*GetPostsResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostsResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostsResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostsResponseArgument(req)))
 	type localValueType struct {
@@ -292,6 +293,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, req *Org_Federation_PostsArgument) (*Posts, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Posts", slog.Any("message_args", s.logvalue_Org_Federation_PostsArgument(req)))
 	type localValueType struct {
@@ -755,6 +757,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Context, req *Org_Federation_Posts_PostItemArgument) (*Posts_PostItem, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts.PostItem")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Posts.PostItem", slog.Any("message_args", s.logvalue_Org_Federation_Posts_PostItemArgument(req)))
 	type localValueType struct {
@@ -796,6 +799,7 @@ func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Co
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -185,6 +185,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -269,6 +270,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -668,6 +670,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
@@ -196,6 +196,7 @@ func (s *FederationService) IsMatch(ctx context.Context, req *IsMatchRequest) (r
 func (s *FederationService) resolve_Org_Federation_IsMatchResponse(ctx context.Context, req *Org_Federation_IsMatchResponseArgument) (*IsMatchResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.IsMatchResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.IsMatchResponse", slog.Any("message_args", s.logvalue_Org_Federation_IsMatchResponseArgument(req)))
 	type localValueType struct {

--- a/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
@@ -159,6 +159,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -192,6 +192,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CustomMessage", slog.Any("message_args", s.logvalue_Org_Federation_CustomMessageArgument(req)))
 	type localValueType struct {
@@ -233,6 +234,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -317,6 +319,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.Context, req *Org_Federation_LocalizedMessageArgument) (*LocalizedMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.LocalizedMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.LocalizedMessage", slog.Any("message_args", s.logvalue_Org_Federation_LocalizedMessageArgument(req)))
 	type localValueType struct {
@@ -358,6 +361,7 @@ func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/_examples/18_load/federation/federation_grpc_federation.pb.go
+++ b/_examples/18_load/federation/federation_grpc_federation.pb.go
@@ -183,6 +183,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -171,6 +171,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.GetPostResponse", slog.Any("message_args", s.logvalue_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -236,6 +237,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve federation.Post", slog.Any("message_args", s.logvalue_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/generator/templates/server.go.tmpl
+++ b/generator/templates/server.go.tmpl
@@ -380,6 +380,7 @@ func (s *{{ $serviceName }}) {{ .Name }}(ctx context.Context, req {{ .RequestTyp
 func (s *{{ $serviceName }}) {{ .ResolverName }}(ctx context.Context, req *{{ .RequestType }}) (*{{ .ReturnType }}, error) {
 	ctx, span := s.tracer.Start(ctx, "{{ .ProtoFQDN }}")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve {{ .ProtoFQDN }}", slog.Any("message_args", s.logvalue_{{ .RequestType }}(req)))
 	{{- if .IsDeclVariables }}

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -204,6 +204,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -318,6 +319,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_async.go
+++ b/generator/testdata/expected_async.go
@@ -231,6 +231,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *Org_Federation_AArgument) (*A, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.A")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.A", slog.Any("message_args", s.logvalue_Org_Federation_AArgument(req)))
 	type localValueType struct {
@@ -342,6 +343,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *Org_Federation_AAArgument) (*AA, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AA")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.AA", slog.Any("message_args", s.logvalue_Org_Federation_AAArgument(req)))
 	type localValueType struct {
@@ -383,6 +385,7 @@ func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *
 func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *Org_Federation_ABArgument) (*AB, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AB")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.AB", slog.Any("message_args", s.logvalue_Org_Federation_ABArgument(req)))
 	type localValueType struct {
@@ -424,6 +427,7 @@ func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *
 func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *Org_Federation_BArgument) (*B, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.B")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.B", slog.Any("message_args", s.logvalue_Org_Federation_BArgument(req)))
 	type localValueType struct {
@@ -465,6 +469,7 @@ func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *Org_Federation_CArgument) (*C, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.C")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.C", slog.Any("message_args", s.logvalue_Org_Federation_CArgument(req)))
 	type localValueType struct {
@@ -506,6 +511,7 @@ func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *Org_Federation_DArgument) (*D, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.D")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.D", slog.Any("message_args", s.logvalue_Org_Federation_DArgument(req)))
 	type localValueType struct {
@@ -547,6 +553,7 @@ func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *Org_Federation_EArgument) (*E, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.E")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.E", slog.Any("message_args", s.logvalue_Org_Federation_EArgument(req)))
 	type localValueType struct {
@@ -588,6 +595,7 @@ func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *Org_Federation_FArgument) (*F, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.F")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.F", slog.Any("message_args", s.logvalue_Org_Federation_FArgument(req)))
 	type localValueType struct {
@@ -629,6 +637,7 @@ func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *Org_Federation_GArgument) (*G, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.G")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.G", slog.Any("message_args", s.logvalue_Org_Federation_GArgument(req)))
 	type localValueType struct {
@@ -670,6 +679,7 @@ func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -1334,6 +1344,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *Org_Federation_HArgument) (*H, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.H")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.H", slog.Any("message_args", s.logvalue_Org_Federation_HArgument(req)))
 	type localValueType struct {
@@ -1375,6 +1386,7 @@ func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *Org_Federation_IArgument) (*I, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.I")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.I", slog.Any("message_args", s.logvalue_Org_Federation_IArgument(req)))
 	type localValueType struct {
@@ -1416,6 +1428,7 @@ func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *Org_Federation_JArgument) (*J, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.J")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.J", slog.Any("message_args", s.logvalue_Org_Federation_JArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -184,6 +184,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -258,6 +259,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -421,6 +423,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -186,6 +186,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -270,6 +271,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -669,6 +671,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -195,6 +195,7 @@ func (s *FederationService) CreatePost(ctx context.Context, req *CreatePostReque
 func (s *FederationService) resolve_Org_Federation_CreatePost(ctx context.Context, req *Org_Federation_CreatePostArgument) (*CreatePost, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CreatePost")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CreatePost", slog.Any("message_args", s.logvalue_Org_Federation_CreatePostArgument(req)))
 	type localValueType struct {
@@ -292,6 +293,7 @@ func (s *FederationService) resolve_Org_Federation_CreatePost(ctx context.Contex
 func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx context.Context, req *Org_Federation_CreatePostResponseArgument) (*CreatePostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CreatePostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CreatePostResponse", slog.Any("message_args", s.logvalue_Org_Federation_CreatePostResponseArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -252,6 +252,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -336,6 +337,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -493,6 +495,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -193,6 +193,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CustomMessage", slog.Any("message_args", s.logvalue_Org_Federation_CustomMessageArgument(req)))
 	type localValueType struct {
@@ -234,6 +235,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -318,6 +320,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.Context, req *Org_Federation_LocalizedMessageArgument) (*LocalizedMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.LocalizedMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.LocalizedMessage", slog.Any("message_args", s.logvalue_Org_Federation_LocalizedMessageArgument(req)))
 	type localValueType struct {
@@ -359,6 +362,7 @@ func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -227,6 +227,7 @@ func (s *FederationService) GetPosts(ctx context.Context, req *GetPostsRequest) 
 func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.Context, req *Org_Federation_GetPostsResponseArgument) (*GetPostsResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostsResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostsResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostsResponseArgument(req)))
 	type localValueType struct {
@@ -311,6 +312,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, req *Org_Federation_PostsArgument) (*Posts, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Posts", slog.Any("message_args", s.logvalue_Org_Federation_PostsArgument(req)))
 	type localValueType struct {
@@ -774,6 +776,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Context, req *Org_Federation_Posts_PostItemArgument) (*Posts_PostItem, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts.PostItem")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Posts.PostItem", slog.Any("message_args", s.logvalue_Org_Federation_Posts_PostItemArgument(req)))
 	type localValueType struct {
@@ -815,6 +818,7 @@ func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Co
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_minimum.go
+++ b/generator/testdata/expected_minimum.go
@@ -161,6 +161,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -215,6 +215,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -426,6 +427,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req *Org_Federation_SubArgument) (*Sub, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Sub")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Sub", slog.Any("message_args", s.logvalue_Org_Federation_SubArgument(req)))
 
@@ -446,6 +448,7 @@ func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req 
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {
@@ -603,6 +606,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, req *Org_Federation_UserIDArgument) (*UserID, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserID")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.UserID", slog.Any("message_args", s.logvalue_Org_Federation_UserIDArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -194,6 +194,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetResponseArgument(req)))
 	type localValueType struct {
@@ -278,6 +279,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *Org_Federation_MArgument) (*M, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.M")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.M", slog.Any("message_args", s.logvalue_Org_Federation_MArgument(req)))
 	type localValueType struct {
@@ -319,6 +321,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {
@@ -453,6 +456,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Context, req *Org_Federation_UserSelectionArgument) (*UserSelection, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserSelection")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.UserSelection", slog.Any("message_args", s.logvalue_Org_Federation_UserSelectionArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -207,6 +207,7 @@ func (s *FederationService) GetPost2(ctx context.Context, req *GetPostRequest) (
 func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.Context, req *Org_Federation_GetPostResponse1Argument) (*GetPostResponse1, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse1")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse1", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponse1Argument(req)))
 	type localValueType struct {
@@ -291,6 +292,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.
 func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.Context, req *Org_Federation_GetPostResponse2Argument) (*GetPostResponse2, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse2")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse2", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponse2Argument(req)))
 	type localValueType struct {
@@ -375,6 +377,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -273,6 +273,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -506,6 +507,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *Org_Federation_MArgument) (*M, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.M")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.M", slog.Any("message_args", s.logvalue_Org_Federation_MArgument(req)))
 	type localValueType struct {
@@ -561,6 +563,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *O
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {
@@ -853,6 +856,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.User", slog.Any("message_args", s.logvalue_Org_Federation_UserArgument(req)))
 	type localValueType struct {
@@ -1103,6 +1107,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 func (s *FederationService) resolve_Org_Federation_Z(ctx context.Context, req *Org_Federation_ZArgument) (*Z, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Z")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Z", slog.Any("message_args", s.logvalue_Org_Federation_ZArgument(req)))
 

--- a/generator/testdata/expected_validation.go
+++ b/generator/testdata/expected_validation.go
@@ -156,6 +156,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.CustomMessage", slog.Any("message_args", s.logvalue_Org_Federation_CustomMessageArgument(req)))
 	type localValueType struct {
@@ -197,6 +198,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.GetPostResponse", slog.Any("message_args", s.logvalue_Org_Federation_GetPostResponseArgument(req)))
 	type localValueType struct {
@@ -604,6 +606,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
+	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx))
 
 	grpcfed.Logger(ctx).DebugContext(ctx, "resolve org.federation.Post", slog.Any("message_args", s.logvalue_Org_Federation_PostArgument(req)))
 	type localValueType struct {


### PR DESCRIPTION
When a field is added using `grpc.federation.log.add`, we expect it to be output to the log of the message in which it is defined, but it is actually also output to the log of the upstream message.
To prevent this, we also call `grpcfed.WithLogger` in the resolver function.


e.g.
Suppose we have the following definition:
```proto
message GetPostResponse {
  option (.grpc.federation.message) = {
    def {
      name: "post"
      message {
        name: "Post"
        args { name: "id", by: "$.id" }
      }
    }
  };
  Post post = 1 [(grpc.federation.field).by = "post"];
}

message Post {
  option (grpc.federation.message) = {
    def [
      {
        name: "res"
        call {
          method: "post.PostService/GetPost"
          request { field: "id", by: "$.id" }      
        }
      },
      { name: "post", by: "res.post", autobind: true },
      { by: "grpc.federation.log.add({'test_post_id': post.id})" }
    ]
  };
  string id = 1;
  string title = 2;
  string content = 3;
}
```

`test_post_id` field is expected to be output only in the log of Post message, but actualy it is also output in the log of GetPostResponse message (last line)

expected:
```
{"time":"2024-06-28T19:14:04.674+09:00","level":"DEBUG","msg":"resolve federation.GetPostResponse","message_args":{"id":"foo"}}
{"time":"2024-06-28T19:14:04.681815+09:00","level":"DEBUG","msg":"resolve federation.Post","message_args":{"id":"foo"}}
{"time":"2024-06-28T19:14:04.682981+09:00","level":"DEBUG","msg":"call post.PostService/GetPost","post.GetPostRequest":{"id":"foo"}}
{"time":"2024-06-28T19:14:04.688373+09:00","level":"DEBUG","msg":"resolved federation.Post","test_post_id":"foo","federation.Post":{"id":"foo","title":"foo","content":"bar"}}
{"time":"2024-06-28T19:14:04.689465+09:00","level":"DEBUG","msg":"resolved federation.GetPostResponse","federation.GetPostResponse":{"post":{"id":"foo","title":"foo","content":"bar"}}}
```

actual:
```
{"time":"2024-06-28T19:14:38.854809+09:00","level":"DEBUG","msg":"resolve federation.GetPostResponse","message_args":{"id":"foo"}}
{"time":"2024-06-28T19:14:38.863336+09:00","level":"DEBUG","msg":"resolve federation.Post","message_args":{"id":"foo"}}
{"time":"2024-06-28T19:14:38.864611+09:00","level":"DEBUG","msg":"call post.PostService/GetPost","post.GetPostRequest":{"id":"foo"}}
{"time":"2024-06-28T19:14:38.871586+09:00","level":"DEBUG","msg":"resolved federation.Post","test_post_id":"foo","federation.Post":{"id":"foo","title":"foo","content":"bar"}}
{"time":"2024-06-28T19:14:38.872723+09:00","level":"DEBUG","msg":"resolved federation.GetPostResponse","test_post_id":"foo","federation.GetPostResponse":{"post":{"id":"foo","title":"foo","content":"bar"}}}
```
