### PR TITLE
Fix message args

### DIFF
--- a/_examples/01_minimum/federation/federation_grpc_federation.pb.go
+++ b/_examples/01_minimum/federation/federation_grpc_federation.pb.go
@@ -23,7 +23,7 @@ var (
 )
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type Federation_GetPostResponseArgument struct {
+type FederationService_Federation_GetPostResponseArgument struct {
 	Id string
 }
 
@@ -58,7 +58,7 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Federation_GetPostResponse implements resolver for "federation.GetPostResponse".
-	Resolve_Federation_GetPostResponse(context.Context, *Federation_GetPostResponseArgument) (*GetPostResponse, error)
+	Resolve_Federation_GetPostResponse(context.Context, *FederationService_Federation_GetPostResponseArgument) (*GetPostResponse, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -76,7 +76,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Federation_GetPostResponse resolve "federation.GetPostResponse".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Federation_GetPostResponse(context.Context, *Federation_GetPostResponseArgument) (ret *GetPostResponse, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Federation_GetPostResponse(context.Context, *FederationService_Federation_GetPostResponseArgument) (ret *GetPostResponse, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_GetPostResponse not implemented")
 	return
 }
@@ -142,7 +142,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetPostResponse(ctx, &Federation_GetPostResponseArgument{
+	res, err := s.resolve_Federation_GetPostResponse(ctx, &FederationService_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Federation_GetPostResponse resolve "federation.GetPostResponse" message.
-func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *FederationService_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -183,7 +183,7 @@ func (s *FederationService) logvalue_Federation_GetPostResponse(v *GetPostRespon
 	)
 }
 
-func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *FederationService_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/01_minimum/main_test.go
+++ b/_examples/01_minimum/main_test.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-func (r *Resolver) Resolve_Federation_GetPostResponse(ctx context.Context, arg *federation.Federation_GetPostResponseArgument) (*federation.GetPostResponse, error) {
+func (r *Resolver) Resolve_Federation_GetPostResponse(ctx context.Context, arg *federation.FederationService_Federation_GetPostResponseArgument) (*federation.GetPostResponse, error) {
 	return testResponse, nil
 }
 

--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -29,23 +29,23 @@ var (
 )
 
 // Federation_AArgument is argument for "federation.A" message.
-type Federation_AArgument struct {
+type FederationService_Federation_AArgument struct {
 	B *A_B
 }
 
 // Federation_A_BArgument is argument for "federation.B" message.
-type Federation_A_BArgument struct {
+type FederationService_Federation_A_BArgument struct {
 	Bar *A_B_C
 	Foo *A_B_C
 }
 
 // Federation_A_B_CArgument is argument for "federation.C" message.
-type Federation_A_B_CArgument struct {
+type FederationService_Federation_A_B_CArgument struct {
 	Type string
 }
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type Federation_GetPostResponseArgument struct {
+type FederationService_Federation_GetPostResponseArgument struct {
 	A            *A
 	Date         *timestamppb.Timestamp
 	FixedRand    *grpcfedcel.Rand
@@ -61,24 +61,8 @@ type Federation_GetPostResponseArgument struct {
 	Value1       string
 }
 
-// Federation_ItemArgument is argument for "federation.Item" message.
-type Federation_ItemArgument struct {
-}
-
-// Federation_Item_LocationArgument is argument for "federation.Location" message.
-type Federation_Item_LocationArgument struct {
-}
-
-// Federation_Item_Location_AddrAArgument is argument for "federation.AddrA" message.
-type Federation_Item_Location_AddrAArgument struct {
-}
-
-// Federation_Item_Location_AddrBArgument is argument for "federation.AddrB" message.
-type Federation_Item_Location_AddrBArgument struct {
-}
-
 // Federation_PostArgument is argument for "federation.Post" message.
-type Federation_PostArgument struct {
+type FederationService_Federation_PostArgument struct {
 	Id   string
 	Post *post.Post
 	Res  *post.GetPostResponse
@@ -86,21 +70,13 @@ type Federation_PostArgument struct {
 }
 
 // Federation_UserArgument is argument for "federation.User" message.
-type Federation_UserArgument struct {
+type FederationService_Federation_UserArgument struct {
 	Content string
 	Id      string
 	Res     *user.GetUserResponse
 	Title   string
 	User    *user.User
 	UserId  string
-}
-
-// Federation_User_AttrAArgument is argument for "federation.AttrA" message.
-type Federation_User_AttrAArgument struct {
-}
-
-// Federation_User_AttrBArgument is argument for "federation.AttrB" message.
-type Federation_User_AttrBArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -250,7 +226,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetPostResponse(ctx, &Federation_GetPostResponseArgument{
+	res, err := s.resolve_Federation_GetPostResponse(ctx, &FederationService_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -262,7 +238,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Federation_A resolve "federation.A" message.
-func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Federation_AArgument) (*A, error) {
+func (s *FederationService) resolve_Federation_A(ctx context.Context, req *FederationService_Federation_AArgument) (*A, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.A")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -298,7 +274,7 @@ func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Feder
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_A_BArgument{}
+			args := &FederationService_Federation_A_BArgument{}
 			return s.resolve_Federation_A_B(ctx, args)
 		},
 	}); err != nil {
@@ -333,7 +309,7 @@ func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Feder
 }
 
 // resolve_Federation_A_B resolve "federation.A.B" message.
-func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Federation_A_BArgument) (*A_B, error) {
+func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *FederationService_Federation_A_BArgument) (*A_B, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.A.B")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -387,7 +363,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Federation_A_B_CArgument{}
+					args := &FederationService_Federation_A_B_CArgument{}
 					// { name: "type", by: "'bar'" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -429,7 +405,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Federation_A_B_CArgument{}
+					args := &FederationService_Federation_A_B_CArgument{}
 					// { name: "type", by: "'foo'" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -505,7 +481,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Federation_A_B_CArgument{}
+					args := &FederationService_Federation_A_B_CArgument{}
 					// { name: "type", by: "'bar'" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -547,7 +523,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Federation_A_B_CArgument{}
+					args := &FederationService_Federation_A_B_CArgument{}
 					// { name: "type", by: "'foo'" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -643,7 +619,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 }
 
 // resolve_Federation_A_B_C resolve "federation.A.B.C" message.
-func (s *FederationService) resolve_Federation_A_B_C(ctx context.Context, req *Federation_A_B_CArgument) (*A_B_C, error) {
+func (s *FederationService) resolve_Federation_A_B_C(ctx context.Context, req *FederationService_Federation_A_B_CArgument) (*A_B_C, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.A.B.C")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -685,7 +661,7 @@ func (s *FederationService) resolve_Federation_A_B_C(ctx context.Context, req *F
 }
 
 // resolve_Federation_GetPostResponse resolve "federation.GetPostResponse" message.
-func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *FederationService_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -753,7 +729,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_PostArgument{}
+				args := &FederationService_Federation_PostArgument{}
 				// { name: "id", by: "$.id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -817,7 +793,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_AArgument{}
+				args := &FederationService_Federation_AArgument{}
 				return s.resolve_Federation_A(ctx, args)
 			},
 		}); err != nil {
@@ -1583,7 +1559,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 }
 
 // resolve_Federation_Post resolve "federation.Post" message.
-func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *FederationService_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1701,7 +1677,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_UserArgument{}
+			args := &FederationService_Federation_UserArgument{}
 			// { inline: "post" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*post.Post]{
 				Value:             value,
@@ -1757,7 +1733,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 }
 
 // resolve_Federation_User resolve "federation.User" message.
-func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Federation_User(ctx context.Context, req *FederationService_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -2303,7 +2279,7 @@ func (s *FederationService) logvalue_Federation_A(v *A) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_AArgument(v *Federation_AArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_AArgument(v *FederationService_Federation_AArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -2320,7 +2296,7 @@ func (s *FederationService) logvalue_Federation_A_B(v *A_B) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_A_BArgument(v *Federation_A_BArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_A_BArgument(v *FederationService_Federation_A_BArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -2336,7 +2312,7 @@ func (s *FederationService) logvalue_Federation_A_B_C(v *A_B_C) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_A_B_CArgument(v *Federation_A_B_CArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_A_B_CArgument(v *FederationService_Federation_A_B_CArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -2383,7 +2359,7 @@ func (s *FederationService) logvalue_Federation_GetPostResponse(v *GetPostRespon
 	)
 }
 
-func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *FederationService_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -2481,7 +2457,7 @@ func (s *FederationService) logvalue_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_PostArgument(v *Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_PostArgument(v *FederationService_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -2504,7 +2480,7 @@ func (s *FederationService) logvalue_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_UserArgument(v *Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_UserArgument(v *FederationService_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -27,19 +27,19 @@ var (
 )
 
 // Federation_V2Dev_ForNamelessArgument is argument for "federation.v2dev.ForNameless" message.
-type Federation_V2Dev_ForNamelessArgument struct {
+type FederationV2DevService_Federation_V2Dev_ForNamelessArgument struct {
 	Bar string
 }
 
 // Federation_V2Dev_GetPostV2DevResponseArgument is argument for "federation.v2dev.GetPostV2devResponse" message.
-type Federation_V2Dev_GetPostV2DevResponseArgument struct {
+type FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseArgument struct {
 	Id   string
 	Post *PostV2Dev
 	R    *Ref
 }
 
 // Federation_V2Dev_PostV2DevArgument is argument for "federation.v2dev.PostV2dev" message.
-type Federation_V2Dev_PostV2DevArgument struct {
+type FederationV2DevService_Federation_V2Dev_PostV2DevArgument struct {
 	Id     string
 	Post   *post.Post
 	Res    *post.GetPostResponse
@@ -49,17 +49,21 @@ type Federation_V2Dev_PostV2DevArgument struct {
 }
 
 // Federation_V2Dev_PostV2Dev_UserArgument is custom resolver's argument for "user" field of "federation.v2dev.PostV2dev" message.
-type Federation_V2Dev_PostV2Dev_UserArgument struct {
-	*Federation_V2Dev_PostV2DevArgument
+type FederationV2DevService_Federation_V2Dev_PostV2Dev_UserArgument struct {
+	*FederationV2DevService_Federation_V2Dev_PostV2DevArgument
+}
+
+// Federation_V2Dev_RefArgument is argument for "federation.v2dev.Ref" message.
+type FederationV2DevService_Federation_V2Dev_RefArgument struct {
 }
 
 // Federation_V2Dev_UnusedArgument is argument for "federation.v2dev.Unused" message.
-type Federation_V2Dev_UnusedArgument struct {
+type FederationV2DevService_Federation_V2Dev_UnusedArgument struct {
 	Foo string
 }
 
 // Federation_V2Dev_UserArgument is argument for "federation.v2dev.User" message.
-type Federation_V2Dev_UserArgument struct {
+type FederationV2DevService_Federation_V2Dev_UserArgument struct {
 	Content string
 	Id      string
 	Res     *user.GetUserResponse
@@ -69,8 +73,8 @@ type Federation_V2Dev_UserArgument struct {
 }
 
 // Federation_V2Dev_User_NameArgument is custom resolver's argument for "name" field of "federation.v2dev.User" message.
-type Federation_V2Dev_User_NameArgument struct {
-	*Federation_V2Dev_UserArgument
+type FederationV2DevService_Federation_V2Dev_User_NameArgument struct {
+	*FederationV2DevService_Federation_V2Dev_UserArgument
 	Federation_V2Dev_User *User
 }
 
@@ -114,15 +118,15 @@ type FederationV2DevServiceDependentClientSet struct {
 // FederationV2DevServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationV2DevServiceResolver interface {
 	// Resolve_Federation_V2Dev_ForNameless implements resolver for "federation.v2dev.ForNameless".
-	Resolve_Federation_V2Dev_ForNameless(context.Context, *Federation_V2Dev_ForNamelessArgument) (*ForNameless, error)
+	Resolve_Federation_V2Dev_ForNameless(context.Context, *FederationV2DevService_Federation_V2Dev_ForNamelessArgument) (*ForNameless, error)
 	// Resolve_Federation_V2Dev_PostV2Dev_User implements resolver for "federation.v2dev.PostV2dev.user".
-	Resolve_Federation_V2Dev_PostV2Dev_User(context.Context, *Federation_V2Dev_PostV2Dev_UserArgument) (*User, error)
+	Resolve_Federation_V2Dev_PostV2Dev_User(context.Context, *FederationV2DevService_Federation_V2Dev_PostV2Dev_UserArgument) (*User, error)
 	// Resolve_Federation_V2Dev_Unused implements resolver for "federation.v2dev.Unused".
-	Resolve_Federation_V2Dev_Unused(context.Context, *Federation_V2Dev_UnusedArgument) (*Unused, error)
+	Resolve_Federation_V2Dev_Unused(context.Context, *FederationV2DevService_Federation_V2Dev_UnusedArgument) (*Unused, error)
 	// Resolve_Federation_V2Dev_User implements resolver for "federation.v2dev.User".
-	Resolve_Federation_V2Dev_User(context.Context, *Federation_V2Dev_UserArgument) (*User, error)
+	Resolve_Federation_V2Dev_User(context.Context, *FederationV2DevService_Federation_V2Dev_UserArgument) (*User, error)
 	// Resolve_Federation_V2Dev_User_Name implements resolver for "federation.v2dev.User.name".
-	Resolve_Federation_V2Dev_User_Name(context.Context, *Federation_V2Dev_User_NameArgument) (string, error)
+	Resolve_Federation_V2Dev_User_Name(context.Context, *FederationV2DevService_Federation_V2Dev_User_NameArgument) (string, error)
 }
 
 // FederationV2DevServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -163,35 +167,35 @@ type FederationV2DevServiceUnimplementedResolver struct{}
 
 // Resolve_Federation_V2Dev_ForNameless resolve "federation.v2dev.ForNameless".
 // This method always returns Unimplemented error.
-func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_ForNameless(context.Context, *Federation_V2Dev_ForNamelessArgument) (ret *ForNameless, e error) {
+func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_ForNameless(context.Context, *FederationV2DevService_Federation_V2Dev_ForNamelessArgument) (ret *ForNameless, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_V2Dev_ForNameless not implemented")
 	return
 }
 
 // Resolve_Federation_V2Dev_PostV2Dev_User resolve "federation.v2dev.PostV2dev.user".
 // This method always returns Unimplemented error.
-func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_PostV2Dev_User(context.Context, *Federation_V2Dev_PostV2Dev_UserArgument) (ret *User, e error) {
+func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_PostV2Dev_User(context.Context, *FederationV2DevService_Federation_V2Dev_PostV2Dev_UserArgument) (ret *User, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_V2Dev_PostV2Dev_User not implemented")
 	return
 }
 
 // Resolve_Federation_V2Dev_Unused resolve "federation.v2dev.Unused".
 // This method always returns Unimplemented error.
-func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_Unused(context.Context, *Federation_V2Dev_UnusedArgument) (ret *Unused, e error) {
+func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_Unused(context.Context, *FederationV2DevService_Federation_V2Dev_UnusedArgument) (ret *Unused, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_V2Dev_Unused not implemented")
 	return
 }
 
 // Resolve_Federation_V2Dev_User resolve "federation.v2dev.User".
 // This method always returns Unimplemented error.
-func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_User(context.Context, *Federation_V2Dev_UserArgument) (ret *User, e error) {
+func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_User(context.Context, *FederationV2DevService_Federation_V2Dev_UserArgument) (ret *User, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_V2Dev_User not implemented")
 	return
 }
 
 // Resolve_Federation_V2Dev_User_Name resolve "federation.v2dev.User.name".
 // This method always returns Unimplemented error.
-func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_User_Name(context.Context, *Federation_V2Dev_User_NameArgument) (ret string, e error) {
+func (FederationV2DevServiceUnimplementedResolver) Resolve_Federation_V2Dev_User_Name(context.Context, *FederationV2DevService_Federation_V2Dev_User_NameArgument) (ret string, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_V2Dev_User_Name not implemented")
 	return
 }
@@ -311,7 +315,7 @@ func (s *FederationV2DevService) GetPostV2Dev(ctx context.Context, req *GetPostV
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_V2Dev_GetPostV2DevResponse(ctx, &Federation_V2Dev_GetPostV2DevResponseArgument{
+	res, err := s.resolve_Federation_V2Dev_GetPostV2DevResponse(ctx, &FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -323,7 +327,7 @@ func (s *FederationV2DevService) GetPostV2Dev(ctx context.Context, req *GetPostV
 }
 
 // resolve_Federation_V2Dev_ForNameless resolve "federation.v2dev.ForNameless" message.
-func (s *FederationV2DevService) resolve_Federation_V2Dev_ForNameless(ctx context.Context, req *Federation_V2Dev_ForNamelessArgument) (*ForNameless, error) {
+func (s *FederationV2DevService) resolve_Federation_V2Dev_ForNameless(ctx context.Context, req *FederationV2DevService_Federation_V2Dev_ForNamelessArgument) (*ForNameless, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.ForNameless")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -344,7 +348,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_ForNameless(ctx contex
 }
 
 // resolve_Federation_V2Dev_GetPostV2DevResponse resolve "federation.v2dev.GetPostV2devResponse" message.
-func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(ctx context.Context, req *Federation_V2Dev_GetPostV2DevResponseArgument) (*GetPostV2DevResponse, error) {
+func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(ctx context.Context, req *FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseArgument) (*GetPostV2DevResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.GetPostV2devResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -391,7 +395,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(c
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_V2Dev_PostV2DevArgument{}
+				args := &FederationV2DevService_Federation_V2Dev_PostV2DevArgument{}
 				// { name: "id", by: "$.id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -433,7 +437,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(c
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_V2Dev_RefArgument{}
+				args := &FederationV2DevService_Federation_V2Dev_RefArgument{}
 				return s.resolve_Federation_V2Dev_Ref(ctx, args)
 			},
 		}); err != nil {
@@ -549,7 +553,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(c
 }
 
 // resolve_Federation_V2Dev_PostV2Dev resolve "federation.v2dev.PostV2dev" message.
-func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.Context, req *Federation_V2Dev_PostV2DevArgument) (*PostV2Dev, error) {
+func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.Context, req *FederationV2DevService_Federation_V2Dev_PostV2DevArgument) (*PostV2Dev, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.PostV2dev")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -602,7 +606,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_V2Dev_ForNamelessArgument{}
+				args := &FederationV2DevService_Federation_V2Dev_ForNamelessArgument{}
 				// { name: "bar", by: "'bar'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -645,7 +649,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_V2Dev_UnusedArgument{}
+				args := &FederationV2DevService_Federation_V2Dev_UnusedArgument{}
 				// { name: "foo", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -753,7 +757,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_V2Dev_UserArgument{}
+				args := &FederationV2DevService_Federation_V2Dev_UserArgument{}
 				// { inline: "post" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*post.Post]{
 					Value:             value,
@@ -801,8 +805,8 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.User, err = s.resolver.Resolve_Federation_V2Dev_PostV2Dev_User(ctx, &Federation_V2Dev_PostV2Dev_UserArgument{
-			Federation_V2Dev_PostV2DevArgument: req,
+		ret.User, err = s.resolver.Resolve_Federation_V2Dev_PostV2Dev_User(ctx, &FederationV2DevService_Federation_V2Dev_PostV2Dev_UserArgument{
+			FederationV2DevService_Federation_V2Dev_PostV2DevArgument: req,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -815,7 +819,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 }
 
 // resolve_Federation_V2Dev_Ref resolve "federation.v2dev.Ref" message.
-func (s *FederationV2DevService) resolve_Federation_V2Dev_Ref(ctx context.Context, req *Federation_V2Dev_RefArgument) (*Ref, error) {
+func (s *FederationV2DevService) resolve_Federation_V2Dev_Ref(ctx context.Context, req *FederationV2DevService_Federation_V2Dev_RefArgument) (*Ref, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.Ref")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -858,7 +862,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_Ref(ctx context.Contex
 }
 
 // resolve_Federation_V2Dev_Unused resolve "federation.v2dev.Unused" message.
-func (s *FederationV2DevService) resolve_Federation_V2Dev_Unused(ctx context.Context, req *Federation_V2Dev_UnusedArgument) (*Unused, error) {
+func (s *FederationV2DevService) resolve_Federation_V2Dev_Unused(ctx context.Context, req *FederationV2DevService_Federation_V2Dev_UnusedArgument) (*Unused, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.Unused")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -879,7 +883,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_Unused(ctx context.Con
 }
 
 // resolve_Federation_V2Dev_User resolve "federation.v2dev.User" message.
-func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Context, req *Federation_V2Dev_UserArgument) (*User, error) {
+func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Context, req *FederationV2DevService_Federation_V2Dev_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.v2dev.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -982,9 +986,9 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Conte
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.Name, err = s.resolver.Resolve_Federation_V2Dev_User_Name(ctx, &Federation_V2Dev_User_NameArgument{
-			Federation_V2Dev_UserArgument: req,
-			Federation_V2Dev_User:         ret,
+		ret.Name, err = s.resolver.Resolve_Federation_V2Dev_User_Name(ctx, &FederationV2DevService_Federation_V2Dev_User_NameArgument{
+			FederationV2DevService_Federation_V2Dev_UserArgument: req,
+			Federation_V2Dev_User:                                ret,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -1025,7 +1029,7 @@ func (s *FederationV2DevService) logvalue_Federation_V2Dev_ForNameless(v *ForNam
 	)
 }
 
-func (s *FederationV2DevService) logvalue_Federation_V2Dev_ForNamelessArgument(v *Federation_V2Dev_ForNamelessArgument) slog.Value {
+func (s *FederationV2DevService) logvalue_Federation_V2Dev_ForNamelessArgument(v *FederationV2DevService_Federation_V2Dev_ForNamelessArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1048,7 +1052,7 @@ func (s *FederationV2DevService) logvalue_Federation_V2Dev_GetPostV2DevResponse(
 	)
 }
 
-func (s *FederationV2DevService) logvalue_Federation_V2Dev_GetPostV2DevResponseArgument(v *Federation_V2Dev_GetPostV2DevResponseArgument) slog.Value {
+func (s *FederationV2DevService) logvalue_Federation_V2Dev_GetPostV2DevResponseArgument(v *FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1069,7 +1073,7 @@ func (s *FederationV2DevService) logvalue_Federation_V2Dev_PostV2Dev(v *PostV2De
 	)
 }
 
-func (s *FederationV2DevService) logvalue_Federation_V2Dev_PostV2DevArgument(v *Federation_V2Dev_PostV2DevArgument) slog.Value {
+func (s *FederationV2DevService) logvalue_Federation_V2Dev_PostV2DevArgument(v *FederationV2DevService_Federation_V2Dev_PostV2DevArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1095,7 +1099,7 @@ func (s *FederationV2DevService) logvalue_Federation_V2Dev_Ref(v *Ref) slog.Valu
 	)
 }
 
-func (s *FederationV2DevService) logvalue_Federation_V2Dev_RefArgument(v *Federation_V2Dev_RefArgument) slog.Value {
+func (s *FederationV2DevService) logvalue_Federation_V2Dev_RefArgument(v *FederationV2DevService_Federation_V2Dev_RefArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1111,7 +1115,7 @@ func (s *FederationV2DevService) logvalue_Federation_V2Dev_Unused(v *Unused) slo
 	)
 }
 
-func (s *FederationV2DevService) logvalue_Federation_V2Dev_UnusedArgument(v *Federation_V2Dev_UnusedArgument) slog.Value {
+func (s *FederationV2DevService) logvalue_Federation_V2Dev_UnusedArgument(v *FederationV2DevService_Federation_V2Dev_UnusedArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1130,7 +1134,7 @@ func (s *FederationV2DevService) logvalue_Federation_V2Dev_User(v *User) slog.Va
 	)
 }
 
-func (s *FederationV2DevService) logvalue_Federation_V2Dev_UserArgument(v *Federation_V2Dev_UserArgument) slog.Value {
+func (s *FederationV2DevService) logvalue_Federation_V2Dev_UserArgument(v *FederationV2DevService_Federation_V2Dev_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/03_custom_resolver/federation/other_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/other_grpc_federation.pb.go
@@ -13,7 +13,3 @@ import (
 var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
-
-// Federation_V2Dev_RefArgument is argument for "federation.v2dev.Ref" message.
-type Federation_V2Dev_RefArgument struct {
-}

--- a/_examples/03_custom_resolver/main_test.go
+++ b/_examples/03_custom_resolver/main_test.go
@@ -51,7 +51,7 @@ func (c *clientConfig) User_UserServiceClient(cfg federation.FederationV2DevServ
 type Resolver struct {
 }
 
-func (r *Resolver) Resolve_Federation_V2Dev_User(ctx context.Context, arg *federation.Federation_V2Dev_UserArgument) (*federation.User, error) {
+func (r *Resolver) Resolve_Federation_V2Dev_User(ctx context.Context, arg *federation.FederationV2DevService_Federation_V2Dev_UserArgument) (*federation.User, error) {
 	grpcfed.SetLogger(ctx, grpcfed.Logger(ctx).With(slog.String("foo", "hoge")))
 	env := federation.GetFederationV2DevServiceEnv(ctx)
 	if env.A != "xxx" {
@@ -74,19 +74,19 @@ func (r *Resolver) Resolve_Federation_V2Dev_User(ctx context.Context, arg *feder
 	}, nil
 }
 
-func (r *Resolver) Resolve_Federation_V2Dev_PostV2Dev_User(ctx context.Context, arg *federation.Federation_V2Dev_PostV2Dev_UserArgument) (*federation.User, error) {
-	return arg.Federation_V2Dev_PostV2DevArgument.User, nil
+func (r *Resolver) Resolve_Federation_V2Dev_PostV2Dev_User(ctx context.Context, arg *federation.FederationV2DevService_Federation_V2Dev_PostV2Dev_UserArgument) (*federation.User, error) {
+	return arg.User, nil
 }
 
-func (r *Resolver) Resolve_Federation_V2Dev_Unused(_ context.Context, _ *federation.Federation_V2Dev_UnusedArgument) (*federation.Unused, error) {
+func (r *Resolver) Resolve_Federation_V2Dev_Unused(_ context.Context, _ *federation.FederationV2DevService_Federation_V2Dev_UnusedArgument) (*federation.Unused, error) {
 	return &federation.Unused{}, nil
 }
 
-func (r *Resolver) Resolve_Federation_V2Dev_ForNameless(_ context.Context, _ *federation.Federation_V2Dev_ForNamelessArgument) (*federation.ForNameless, error) {
+func (r *Resolver) Resolve_Federation_V2Dev_ForNameless(_ context.Context, _ *federation.FederationV2DevService_Federation_V2Dev_ForNamelessArgument) (*federation.ForNameless, error) {
 	return &federation.ForNameless{}, nil
 }
 
-func (r *Resolver) Resolve_Federation_V2Dev_User_Name(ctx context.Context, arg *federation.Federation_V2Dev_User_NameArgument) (string, error) {
+func (r *Resolver) Resolve_Federation_V2Dev_User_Name(ctx context.Context, arg *federation.FederationV2DevService_Federation_V2Dev_User_NameArgument) (string, error) {
 	return arg.Federation_V2Dev_User.Name, nil
 }
 

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -25,13 +25,13 @@ var (
 )
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type Federation_GetPostResponseArgument struct {
+type FederationService_Federation_GetPostResponseArgument struct {
 	Id   string
 	Post *Post
 }
 
 // Federation_PostArgument is argument for "federation.Post" message.
-type Federation_PostArgument struct {
+type FederationService_Federation_PostArgument struct {
 	Id   string
 	Post *post.Post
 	Res  *post.GetPostResponse
@@ -160,7 +160,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 		}
 	}()
 	res, err := grpcfed.WithTimeout[GetPostResponse](ctx, "federation.FederationService/GetPost", 1000000000 /* 1s */, func(ctx context.Context) (*GetPostResponse, error) {
-		return s.resolve_Federation_GetPostResponse(ctx, &Federation_GetPostResponseArgument{
+		return s.resolve_Federation_GetPostResponse(ctx, &FederationService_Federation_GetPostResponseArgument{
 			Id: req.GetId(),
 		})
 	})
@@ -173,7 +173,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Federation_GetPostResponse resolve "federation.GetPostResponse" message.
-func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *FederationService_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -210,7 +210,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_PostArgument{}
+			args := &FederationService_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -258,7 +258,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 }
 
 // resolve_Federation_Post resolve "federation.Post" message.
-func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *FederationService_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -368,7 +368,7 @@ func (s *FederationService) logvalue_Federation_GetPostResponse(v *GetPostRespon
 	)
 }
 
-func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *FederationService_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -388,7 +388,7 @@ func (s *FederationService) logvalue_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_PostArgument(v *Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_PostArgument(v *FederationService_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/05_async/federation/federation_grpc_federation.pb.go
+++ b/_examples/05_async/federation/federation_grpc_federation.pb.go
@@ -23,49 +23,49 @@ var (
 )
 
 // Org_Federation_AAArgument is argument for "org.federation.AA" message.
-type Org_Federation_AAArgument struct {
+type FederationService_Org_Federation_AAArgument struct {
 }
 
 // Org_Federation_AArgument is argument for "org.federation.A" message.
-type Org_Federation_AArgument struct {
+type FederationService_Org_Federation_AArgument struct {
 }
 
 // Org_Federation_ABArgument is argument for "org.federation.AB" message.
-type Org_Federation_ABArgument struct {
+type FederationService_Org_Federation_ABArgument struct {
 }
 
 // Org_Federation_BArgument is argument for "org.federation.B" message.
-type Org_Federation_BArgument struct {
+type FederationService_Org_Federation_BArgument struct {
 }
 
 // Org_Federation_CArgument is argument for "org.federation.C" message.
-type Org_Federation_CArgument struct {
+type FederationService_Org_Federation_CArgument struct {
 	A string
 }
 
 // Org_Federation_DArgument is argument for "org.federation.D" message.
-type Org_Federation_DArgument struct {
+type FederationService_Org_Federation_DArgument struct {
 	B string
 }
 
 // Org_Federation_EArgument is argument for "org.federation.E" message.
-type Org_Federation_EArgument struct {
+type FederationService_Org_Federation_EArgument struct {
 	C string
 	D string
 }
 
 // Org_Federation_FArgument is argument for "org.federation.F" message.
-type Org_Federation_FArgument struct {
+type FederationService_Org_Federation_FArgument struct {
 	C string
 	D string
 }
 
 // Org_Federation_GArgument is argument for "org.federation.G" message.
-type Org_Federation_GArgument struct {
+type FederationService_Org_Federation_GArgument struct {
 }
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	A *A
 	B *B
 	C *C
@@ -79,18 +79,18 @@ type Org_Federation_GetResponseArgument struct {
 }
 
 // Org_Federation_HArgument is argument for "org.federation.H" message.
-type Org_Federation_HArgument struct {
+type FederationService_Org_Federation_HArgument struct {
 	E string
 	F string
 	G string
 }
 
 // Org_Federation_IArgument is argument for "org.federation.I" message.
-type Org_Federation_IArgument struct {
+type FederationService_Org_Federation_IArgument struct {
 }
 
 // Org_Federation_JArgument is argument for "org.federation.J" message.
-type Org_Federation_JArgument struct {
+type FederationService_Org_Federation_JArgument struct {
 	I string
 }
 
@@ -218,7 +218,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -228,7 +228,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_A resolve "org.federation.A" message.
-func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *Org_Federation_AArgument) (*A, error) {
+func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *FederationService_Org_Federation_AArgument) (*A, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.A")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -273,7 +273,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_AAArgument{}
+				args := &FederationService_Org_Federation_AAArgument{}
 				return s.resolve_Org_Federation_AA(ctx, args)
 			},
 		}); err != nil {
@@ -302,7 +302,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_ABArgument{}
+				args := &FederationService_Org_Federation_ABArgument{}
 				return s.resolve_Org_Federation_AB(ctx, args)
 			},
 		}); err != nil {
@@ -340,7 +340,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_AA resolve "org.federation.AA" message.
-func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *Org_Federation_AAArgument) (*AA, error) {
+func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *FederationService_Org_Federation_AAArgument) (*AA, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AA")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -382,7 +382,7 @@ func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *
 }
 
 // resolve_Org_Federation_AB resolve "org.federation.AB" message.
-func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *Org_Federation_ABArgument) (*AB, error) {
+func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *FederationService_Org_Federation_ABArgument) (*AB, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AB")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -424,7 +424,7 @@ func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *
 }
 
 // resolve_Org_Federation_B resolve "org.federation.B" message.
-func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *Org_Federation_BArgument) (*B, error) {
+func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *FederationService_Org_Federation_BArgument) (*B, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.B")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -466,7 +466,7 @@ func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_C resolve "org.federation.C" message.
-func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *Org_Federation_CArgument) (*C, error) {
+func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *FederationService_Org_Federation_CArgument) (*C, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.C")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -508,7 +508,7 @@ func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_D resolve "org.federation.D" message.
-func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *Org_Federation_DArgument) (*D, error) {
+func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *FederationService_Org_Federation_DArgument) (*D, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.D")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -550,7 +550,7 @@ func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_E resolve "org.federation.E" message.
-func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *Org_Federation_EArgument) (*E, error) {
+func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *FederationService_Org_Federation_EArgument) (*E, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.E")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -592,7 +592,7 @@ func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_F resolve "org.federation.F" message.
-func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *Org_Federation_FArgument) (*F, error) {
+func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *FederationService_Org_Federation_FArgument) (*F, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.F")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -634,7 +634,7 @@ func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_G resolve "org.federation.G" message.
-func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *Org_Federation_GArgument) (*G, error) {
+func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *FederationService_Org_Federation_GArgument) (*G, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.G")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -676,7 +676,7 @@ func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -745,7 +745,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_AArgument{}
+						args := &FederationService_Org_Federation_AArgument{}
 						return s.resolve_Org_Federation_A(ctx, args)
 					},
 				}); err != nil {
@@ -771,7 +771,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_CArgument{}
+						args := &FederationService_Org_Federation_CArgument{}
 						// { name: "a", by: "a.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -812,7 +812,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_BArgument{}
+						args := &FederationService_Org_Federation_BArgument{}
 						return s.resolve_Org_Federation_B(ctx, args)
 					},
 				}); err != nil {
@@ -838,7 +838,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_DArgument{}
+						args := &FederationService_Org_Federation_DArgument{}
 						// { name: "b", by: "b.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -885,7 +885,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Org_Federation_EArgument{}
+					args := &FederationService_Org_Federation_EArgument{}
 					// { name: "c", by: "c.name" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -941,7 +941,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_AArgument{}
+						args := &FederationService_Org_Federation_AArgument{}
 						return s.resolve_Org_Federation_A(ctx, args)
 					},
 				}); err != nil {
@@ -967,7 +967,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_CArgument{}
+						args := &FederationService_Org_Federation_CArgument{}
 						// { name: "a", by: "a.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -1008,7 +1008,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_BArgument{}
+						args := &FederationService_Org_Federation_BArgument{}
 						return s.resolve_Org_Federation_B(ctx, args)
 					},
 				}); err != nil {
@@ -1034,7 +1034,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_DArgument{}
+						args := &FederationService_Org_Federation_DArgument{}
 						// { name: "b", by: "b.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -1081,7 +1081,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Org_Federation_FArgument{}
+					args := &FederationService_Org_Federation_FArgument{}
 					// { name: "c", by: "c.name" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -1135,7 +1135,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Org_Federation_GArgument{}
+					args := &FederationService_Org_Federation_GArgument{}
 					return s.resolve_Org_Federation_G(ctx, args)
 				},
 			}); err != nil {
@@ -1170,7 +1170,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_HArgument{}
+				args := &FederationService_Org_Federation_HArgument{}
 				// { name: "e", by: "e.name" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -1238,7 +1238,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_IArgument{}
+				args := &FederationService_Org_Federation_IArgument{}
 				return s.resolve_Org_Federation_I(ctx, args)
 			},
 		}); err != nil {
@@ -1264,7 +1264,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_JArgument{}
+				args := &FederationService_Org_Federation_JArgument{}
 				// { name: "i", by: "i.name" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -1341,7 +1341,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 }
 
 // resolve_Org_Federation_H resolve "org.federation.H" message.
-func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *Org_Federation_HArgument) (*H, error) {
+func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *FederationService_Org_Federation_HArgument) (*H, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.H")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1383,7 +1383,7 @@ func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_I resolve "org.federation.I" message.
-func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *Org_Federation_IArgument) (*I, error) {
+func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *FederationService_Org_Federation_IArgument) (*I, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.I")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1425,7 +1425,7 @@ func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_J resolve "org.federation.J" message.
-func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *Org_Federation_JArgument) (*J, error) {
+func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *FederationService_Org_Federation_JArgument) (*J, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.J")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1484,14 +1484,14 @@ func (s *FederationService) logvalue_Org_Federation_AA(v *AA) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_AAArgument(v *Org_Federation_AAArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_AAArgument(v *FederationService_Org_Federation_AAArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Org_Federation_AArgument(v *Org_Federation_AArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_AArgument(v *FederationService_Org_Federation_AArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1507,7 +1507,7 @@ func (s *FederationService) logvalue_Org_Federation_AB(v *AB) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_ABArgument(v *Org_Federation_ABArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_ABArgument(v *FederationService_Org_Federation_ABArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1523,7 +1523,7 @@ func (s *FederationService) logvalue_Org_Federation_B(v *B) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_BArgument(v *Org_Federation_BArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_BArgument(v *FederationService_Org_Federation_BArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1539,7 +1539,7 @@ func (s *FederationService) logvalue_Org_Federation_C(v *C) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CArgument(v *Org_Federation_CArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CArgument(v *FederationService_Org_Federation_CArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1557,7 +1557,7 @@ func (s *FederationService) logvalue_Org_Federation_D(v *D) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_DArgument(v *Org_Federation_DArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_DArgument(v *FederationService_Org_Federation_DArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1575,7 +1575,7 @@ func (s *FederationService) logvalue_Org_Federation_E(v *E) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_EArgument(v *Org_Federation_EArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_EArgument(v *FederationService_Org_Federation_EArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1594,7 +1594,7 @@ func (s *FederationService) logvalue_Org_Federation_F(v *F) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_FArgument(v *Org_Federation_FArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_FArgument(v *FederationService_Org_Federation_FArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1613,7 +1613,7 @@ func (s *FederationService) logvalue_Org_Federation_G(v *G) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GArgument(v *Org_Federation_GArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GArgument(v *FederationService_Org_Federation_GArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1630,7 +1630,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1646,7 +1646,7 @@ func (s *FederationService) logvalue_Org_Federation_H(v *H) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_HArgument(v *Org_Federation_HArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_HArgument(v *FederationService_Org_Federation_HArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1666,7 +1666,7 @@ func (s *FederationService) logvalue_Org_Federation_I(v *I) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_IArgument(v *Org_Federation_IArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_IArgument(v *FederationService_Org_Federation_IArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1682,7 +1682,7 @@ func (s *FederationService) logvalue_Org_Federation_J(v *J) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_JArgument(v *Org_Federation_JArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_JArgument(v *FederationService_Org_Federation_JArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -25,16 +25,8 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostRequest_ConditionAArgument is argument for "org.federation.ConditionA" message.
-type Org_Federation_GetPostRequest_ConditionAArgument struct {
-}
-
-// Org_Federation_GetPostRequest_ConditionBArgument is argument for "org.federation.ConditionB" message.
-type Org_Federation_GetPostRequest_ConditionBArgument struct {
-}
-
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	A          *GetPostRequest_ConditionA
 	ConditionB *GetPostRequest_ConditionB
 	Id         string
@@ -42,7 +34,7 @@ type Org_Federation_GetPostResponseArgument struct {
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	A         *GetPostRequest_ConditionA
 	B         *GetPostRequest_ConditionB
 	Data2     *postv2.PostData
@@ -52,14 +44,6 @@ type Org_Federation_PostArgument struct {
 	Post      *post.Post
 	Res       *post.GetPostResponse
 	Res2      *postv2.GetPostResponse
-}
-
-// Org_Federation_PostContentArgument is argument for "org.federation.PostContent" message.
-type Org_Federation_PostContentArgument struct {
-}
-
-// Org_Federation_PostDataArgument is argument for "org.federation.PostData" message.
-type Org_Federation_PostDataArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -205,7 +189,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id:         req.GetId(),
 		A:          req.GetA(),
 		ConditionB: req.GetConditionB(),
@@ -219,7 +203,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -260,7 +244,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -334,7 +318,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -893,7 +877,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -916,7 +900,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -25,13 +25,13 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id    string
 	XDef0 *Post
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id    string
 	Res   *post.GetPostResponse
 	XDef1 *post.Post
@@ -39,7 +39,7 @@ type Org_Federation_PostArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	UserId string
 }
 
@@ -168,7 +168,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -218,7 +218,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -256,7 +256,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -374,7 +374,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -420,7 +420,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -473,7 +473,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -494,7 +494,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -512,7 +512,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -24,12 +24,8 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_ContentArgument is argument for "org.federation.Content" message.
-type Org_Federation_ContentArgument struct {
-}
-
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	Content *content.Content
 	Id      string
 	Res     *content.GetContentResponse
@@ -156,7 +152,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -168,7 +164,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1189,7 +1185,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -25,18 +25,18 @@ var (
 )
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	Uid   *UserID
 	User  *User
 	User2 *User
 }
 
 // Org_Federation_SubArgument is argument for "org.federation.Sub" message.
-type Org_Federation_SubArgument struct {
+type FederationService_Org_Federation_SubArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Res    *user.GetUserResponse
 	User   *user.User
 	UserId string
@@ -44,12 +44,12 @@ type Org_Federation_UserArgument struct {
 }
 
 // Org_Federation_UserIDArgument is argument for "org.federation.UserID" message.
-type Org_Federation_UserIDArgument struct {
+type FederationService_Org_Federation_UserIDArgument struct {
 }
 
 // Org_Federation_User_NameArgument is custom resolver's argument for "name" field of "org.federation.User" message.
-type Org_Federation_User_NameArgument struct {
-	*Org_Federation_UserArgument
+type FederationService_Org_Federation_User_NameArgument struct {
+	*FederationService_Org_Federation_UserArgument
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -89,9 +89,9 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_Sub implements resolver for "org.federation.Sub".
-	Resolve_Org_Federation_Sub(context.Context, *Org_Federation_SubArgument) (*Sub, error)
+	Resolve_Org_Federation_Sub(context.Context, *FederationService_Org_Federation_SubArgument) (*Sub, error)
 	// Resolve_Org_Federation_User_Name implements resolver for "org.federation.User.name".
-	Resolve_Org_Federation_User_Name(context.Context, *Org_Federation_User_NameArgument) (string, error)
+	Resolve_Org_Federation_User_Name(context.Context, *FederationService_Org_Federation_User_NameArgument) (string, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -109,14 +109,14 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_Sub resolve "org.federation.Sub".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Sub(context.Context, *Org_Federation_SubArgument) (ret *Sub, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Sub(context.Context, *FederationService_Org_Federation_SubArgument) (ret *Sub, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_Sub not implemented")
 	return
 }
 
 // Resolve_Org_Federation_User_Name resolve "org.federation.User.name".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Name(context.Context, *Org_Federation_User_NameArgument) (ret string, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Name(context.Context, *FederationService_Org_Federation_User_NameArgument) (ret string, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_User_Name not implemented")
 	return
 }
@@ -200,7 +200,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -210,7 +210,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -258,7 +258,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserIDArgument{}
+				args := &FederationService_Org_Federation_UserIDArgument{}
 				return s.resolve_Org_Federation_UserID(ctx, args)
 			},
 		}); err != nil {
@@ -284,7 +284,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "uid.value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -326,7 +326,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserIDArgument{}
+				args := &FederationService_Org_Federation_UserIDArgument{}
 				return s.resolve_Org_Federation_UserID(ctx, args)
 			},
 		}); err != nil {
@@ -352,7 +352,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "uid.value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -422,7 +422,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 }
 
 // resolve_Org_Federation_Sub resolve "org.federation.Sub" message.
-func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req *Org_Federation_SubArgument) (*Sub, error) {
+func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req *FederationService_Org_Federation_SubArgument) (*Sub, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Sub")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -443,7 +443,7 @@ func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req 
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -490,7 +490,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_SubArgument{}
+				args := &FederationService_Org_Federation_SubArgument{}
 				return s.resolve_Org_Federation_Sub(ctx, args)
 			},
 		}); err != nil {
@@ -587,8 +587,8 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.Name, err = s.resolver.Resolve_Org_Federation_User_Name(ctx, &Org_Federation_User_NameArgument{
-			Org_Federation_UserArgument: req,
+		ret.Name, err = s.resolver.Resolve_Org_Federation_User_Name(ctx, &FederationService_Org_Federation_User_NameArgument{
+			FederationService_Org_Federation_UserArgument: req,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -601,7 +601,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 }
 
 // resolve_Org_Federation_UserID resolve "org.federation.UserID" message.
-func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, req *Org_Federation_UserIDArgument) (*UserID, error) {
+func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, req *FederationService_Org_Federation_UserIDArgument) (*UserID, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserID")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -637,7 +637,7 @@ func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, r
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_SubArgument{}
+			args := &FederationService_Org_Federation_SubArgument{}
 			return s.resolve_Org_Federation_Sub(ctx, args)
 		},
 	}); err != nil {
@@ -678,7 +678,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -692,7 +692,7 @@ func (s *FederationService) logvalue_Org_Federation_Sub(v *Sub) slog.Value {
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Org_Federation_SubArgument(v *Org_Federation_SubArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_SubArgument(v *FederationService_Org_Federation_SubArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -709,7 +709,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -727,7 +727,7 @@ func (s *FederationService) logvalue_Org_Federation_UserID(v *UserID) slog.Value
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserIDArgument(v *Org_Federation_UserIDArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserIDArgument(v *FederationService_Org_Federation_UserIDArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/09_multi_user/main_test.go
+++ b/_examples/09_multi_user/main_test.go
@@ -55,11 +55,11 @@ func (s *UserServer) GetUser(ctx context.Context, req *user.GetUserRequest) (*us
 
 type resolver struct{}
 
-func (r *resolver) Resolve_Org_Federation_Sub(_ context.Context, _ *federation.Org_Federation_SubArgument) (*federation.Sub, error) {
+func (r *resolver) Resolve_Org_Federation_Sub(_ context.Context, _ *federation.FederationService_Org_Federation_SubArgument) (*federation.Sub, error) {
 	return &federation.Sub{}, nil
 }
 
-func (r *resolver) Resolve_Org_Federation_User_Name(_ context.Context, arg *federation.Org_Federation_User_NameArgument) (string, error) {
+func (r *resolver) Resolve_Org_Federation_User_Name(_ context.Context, arg *federation.FederationService_Org_Federation_User_NameArgument) (string, error) {
 	return arg.User.Name, nil
 }
 

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -25,28 +25,24 @@ var (
 )
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	MsgSel *MessageSelection
 	Sel    *UserSelection
 }
 
-// Org_Federation_MArgument is argument for "org.federation.M" message.
-type Org_Federation_MArgument struct {
-}
-
 // Org_Federation_MessageSelectionArgument is argument for "org.federation.MessageSelection" message.
-type Org_Federation_MessageSelectionArgument struct {
+type FederationService_Org_Federation_MessageSelectionArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Bar    string
 	Foo    int64
 	UserId string
 }
 
 // Org_Federation_UserSelectionArgument is argument for "org.federation.UserSelection" message.
-type Org_Federation_UserSelectionArgument struct {
+type FederationService_Org_Federation_UserSelectionArgument struct {
 	Ua    *User
 	Ub    *User
 	Uc    *User
@@ -195,7 +191,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -205,7 +201,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -250,7 +246,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_MessageSelectionArgument{}
+				args := &FederationService_Org_Federation_MessageSelectionArgument{}
 				return s.resolve_Org_Federation_MessageSelection(ctx, args)
 			},
 		}); err != nil {
@@ -280,7 +276,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserSelectionArgument{}
+				args := &FederationService_Org_Federation_UserSelectionArgument{}
 				// { name: "value", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -349,7 +345,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 }
 
 // resolve_Org_Federation_MessageSelection resolve "org.federation.MessageSelection" message.
-func (s *FederationService) resolve_Org_Federation_MessageSelection(ctx context.Context, req *Org_Federation_MessageSelectionArgument) (*MessageSelection, error) {
+func (s *FederationService) resolve_Org_Federation_MessageSelection(ctx context.Context, req *FederationService_Org_Federation_MessageSelectionArgument) (*MessageSelection, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.MessageSelection")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -446,7 +442,7 @@ func (s *FederationService) resolve_Org_Federation_MessageSelection(ctx context.
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -581,7 +577,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 }
 
 // resolve_Org_Federation_UserSelection resolve "org.federation.UserSelection" message.
-func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Context, req *Org_Federation_UserSelectionArgument) (*UserSelection, error) {
+func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Context, req *FederationService_Org_Federation_UserSelectionArgument) (*UserSelection, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserSelection")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -658,7 +654,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "'a'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -741,7 +737,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "'b'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -824,7 +820,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "$.value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -899,7 +895,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -917,7 +913,7 @@ func (s *FederationService) logvalue_Org_Federation_MessageSelection(v *MessageS
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_MessageSelectionArgument(v *Org_Federation_MessageSelectionArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_MessageSelectionArgument(v *FederationService_Org_Federation_MessageSelectionArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -933,7 +929,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -955,7 +951,7 @@ func (s *FederationService) logvalue_Org_Federation_UserSelection(v *UserSelecti
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserSelectionArgument(v *Org_Federation_UserSelectionArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserSelectionArgument(v *FederationService_Org_Federation_UserSelectionArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
@@ -26,30 +26,31 @@ var (
 )
 
 // Federation_GetNameResponseArgument is argument for "federation.GetNameResponse" message.
-type Federation_GetNameResponseArgument struct {
+type FederationService_Federation_GetNameResponseArgument struct {
 }
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type Federation_GetPostResponseArgument struct {
+type FederationService_Federation_GetPostResponseArgument struct {
 	Id string
 	P  *Post
 }
 
-// Federation_GetStatusResponseArgument is argument for "federation.GetStatusResponse" message.
-type Federation_GetStatusResponseArgument struct {
-	U *User
-}
-
 // Federation_PostArgument is argument for "federation.Post" message.
-type Federation_PostArgument struct {
+type FederationService_Federation_PostArgument struct {
 	Cmp           bool
 	FavoriteValue favorite.FavoriteType
 	Reaction      *Reaction
 	U             *User
 }
 
+// Federation_ReactionArgument is argument for "federation.Reaction" message.
+type FederationService_Federation_ReactionArgument struct {
+	Cmp bool
+	V   favorite.FavoriteType
+}
+
 // Federation_UserArgument is argument for "federation.User" message.
-type Federation_UserArgument struct {
+type FederationService_Federation_UserArgument struct {
 	Id   string
 	Name string
 }
@@ -197,7 +198,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetPostResponse(ctx, &Federation_GetPostResponseArgument{
+	res, err := s.resolve_Federation_GetPostResponse(ctx, &FederationService_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -221,7 +222,7 @@ func (s *FederationService) GetName(ctx context.Context, req *GetNameRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetNameResponse(ctx, &Federation_GetNameResponseArgument{})
+	res, err := s.resolve_Federation_GetNameResponse(ctx, &FederationService_Federation_GetNameResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -231,7 +232,7 @@ func (s *FederationService) GetName(ctx context.Context, req *GetNameRequest) (r
 }
 
 // resolve_Federation_GetNameResponse resolve "federation.GetNameResponse" message.
-func (s *FederationService) resolve_Federation_GetNameResponse(ctx context.Context, req *Federation_GetNameResponseArgument) (*GetNameResponse, error) {
+func (s *FederationService) resolve_Federation_GetNameResponse(ctx context.Context, req *FederationService_Federation_GetNameResponseArgument) (*GetNameResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetNameResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -274,7 +275,7 @@ func (s *FederationService) resolve_Federation_GetNameResponse(ctx context.Conte
 }
 
 // resolve_Federation_GetPostResponse resolve "federation.GetPostResponse" message.
-func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *FederationService_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -311,7 +312,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_PostArgument{}
+			args := &FederationService_Federation_PostArgument{}
 			return s.resolve_Federation_Post(ctx, args)
 		},
 	}); err != nil {
@@ -346,7 +347,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 }
 
 // resolve_Federation_Post resolve "federation.Post" message.
-func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *FederationService_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -468,7 +469,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_ReactionArgument{}
+				args := &FederationService_Federation_ReactionArgument{}
 				// { name: "v", by: "favorite_value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[favorite.FavoriteType]{
 					Value:             value,
@@ -514,7 +515,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_UserArgument{}
+				args := &FederationService_Federation_UserArgument{}
 				// { name: "id", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -672,7 +673,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 }
 
 // resolve_Federation_Reaction resolve "federation.Reaction" message.
-func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req *Federation_ReactionArgument) (*Reaction, error) {
+func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req *FederationService_Federation_ReactionArgument) (*Reaction, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Reaction")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -769,7 +770,7 @@ func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req
 }
 
 // resolve_Federation_User resolve "federation.User" message.
-func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Federation_User(ctx context.Context, req *FederationService_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -863,7 +864,7 @@ func (s *FederationService) logvalue_Federation_GetNameResponse(v *GetNameRespon
 	)
 }
 
-func (s *FederationService) logvalue_Federation_GetNameResponseArgument(v *Federation_GetNameResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_GetNameResponseArgument(v *FederationService_Federation_GetNameResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -879,7 +880,7 @@ func (s *FederationService) logvalue_Federation_GetPostResponse(v *GetPostRespon
 	)
 }
 
-func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *FederationService_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -913,7 +914,7 @@ func (s *FederationService) logvalue_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_PostArgument(v *Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_PostArgument(v *FederationService_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -931,7 +932,7 @@ func (s *FederationService) logvalue_Federation_Reaction(v *Reaction) slog.Value
 	)
 }
 
-func (s *FederationService) logvalue_Federation_ReactionArgument(v *Federation_ReactionArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_ReactionArgument(v *FederationService_Federation_ReactionArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -950,7 +951,7 @@ func (s *FederationService) logvalue_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Federation_UserArgument(v *Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_UserArgument(v *FederationService_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -958,6 +959,36 @@ func (s *FederationService) logvalue_Federation_UserArgument(v *Federation_UserA
 		slog.String("id", v.Id),
 		slog.String("name", v.Name),
 	)
+}
+
+// Federation_GetNameResponseArgument is argument for "federation.GetNameResponse" message.
+type PrivateService_Federation_GetNameResponseArgument struct {
+}
+
+// Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
+type PrivateService_Federation_GetPostResponseArgument struct {
+	Id string
+	P  *Post
+}
+
+// Federation_PostArgument is argument for "federation.Post" message.
+type PrivateService_Federation_PostArgument struct {
+	Cmp           bool
+	FavoriteValue favorite.FavoriteType
+	Reaction      *Reaction
+	U             *User
+}
+
+// Federation_ReactionArgument is argument for "federation.Reaction" message.
+type PrivateService_Federation_ReactionArgument struct {
+	Cmp bool
+	V   favorite.FavoriteType
+}
+
+// Federation_UserArgument is argument for "federation.User" message.
+type PrivateService_Federation_UserArgument struct {
+	Id   string
+	Name string
 }
 
 // PrivateServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -1103,7 +1134,7 @@ func (s *PrivateService) GetPost(ctx context.Context, req *GetPostRequest) (res 
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetPostResponse(ctx, &Federation_GetPostResponseArgument{
+	res, err := s.resolve_Federation_GetPostResponse(ctx, &PrivateService_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -1127,7 +1158,7 @@ func (s *PrivateService) GetName(ctx context.Context, req *GetNameRequest) (res 
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetNameResponse(ctx, &Federation_GetNameResponseArgument{})
+	res, err := s.resolve_Federation_GetNameResponse(ctx, &PrivateService_Federation_GetNameResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -1137,7 +1168,7 @@ func (s *PrivateService) GetName(ctx context.Context, req *GetNameRequest) (res 
 }
 
 // resolve_Federation_GetNameResponse resolve "federation.GetNameResponse" message.
-func (s *PrivateService) resolve_Federation_GetNameResponse(ctx context.Context, req *Federation_GetNameResponseArgument) (*GetNameResponse, error) {
+func (s *PrivateService) resolve_Federation_GetNameResponse(ctx context.Context, req *PrivateService_Federation_GetNameResponseArgument) (*GetNameResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetNameResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1180,7 +1211,7 @@ func (s *PrivateService) resolve_Federation_GetNameResponse(ctx context.Context,
 }
 
 // resolve_Federation_GetPostResponse resolve "federation.GetPostResponse" message.
-func (s *PrivateService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *PrivateService) resolve_Federation_GetPostResponse(ctx context.Context, req *PrivateService_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1217,7 +1248,7 @@ func (s *PrivateService) resolve_Federation_GetPostResponse(ctx context.Context,
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_PostArgument{}
+			args := &PrivateService_Federation_PostArgument{}
 			return s.resolve_Federation_Post(ctx, args)
 		},
 	}); err != nil {
@@ -1252,7 +1283,7 @@ func (s *PrivateService) resolve_Federation_GetPostResponse(ctx context.Context,
 }
 
 // resolve_Federation_Post resolve "federation.Post" message.
-func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
+func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *PrivateService_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1374,7 +1405,7 @@ func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *Feder
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_ReactionArgument{}
+				args := &PrivateService_Federation_ReactionArgument{}
 				// { name: "v", by: "favorite_value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[favorite.FavoriteType]{
 					Value:             value,
@@ -1420,7 +1451,7 @@ func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *Feder
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_UserArgument{}
+				args := &PrivateService_Federation_UserArgument{}
 				// { name: "id", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -1578,7 +1609,7 @@ func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *Feder
 }
 
 // resolve_Federation_Reaction resolve "federation.Reaction" message.
-func (s *PrivateService) resolve_Federation_Reaction(ctx context.Context, req *Federation_ReactionArgument) (*Reaction, error) {
+func (s *PrivateService) resolve_Federation_Reaction(ctx context.Context, req *PrivateService_Federation_ReactionArgument) (*Reaction, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Reaction")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1675,7 +1706,7 @@ func (s *PrivateService) resolve_Federation_Reaction(ctx context.Context, req *F
 }
 
 // resolve_Federation_User resolve "federation.User" message.
-func (s *PrivateService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
+func (s *PrivateService) resolve_Federation_User(ctx context.Context, req *PrivateService_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1769,7 +1800,7 @@ func (s *PrivateService) logvalue_Federation_GetNameResponse(v *GetNameResponse)
 	)
 }
 
-func (s *PrivateService) logvalue_Federation_GetNameResponseArgument(v *Federation_GetNameResponseArgument) slog.Value {
+func (s *PrivateService) logvalue_Federation_GetNameResponseArgument(v *PrivateService_Federation_GetNameResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1785,7 +1816,7 @@ func (s *PrivateService) logvalue_Federation_GetPostResponse(v *GetPostResponse)
 	)
 }
 
-func (s *PrivateService) logvalue_Federation_GetPostResponseArgument(v *Federation_GetPostResponseArgument) slog.Value {
+func (s *PrivateService) logvalue_Federation_GetPostResponseArgument(v *PrivateService_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1819,7 +1850,7 @@ func (s *PrivateService) logvalue_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *PrivateService) logvalue_Federation_PostArgument(v *Federation_PostArgument) slog.Value {
+func (s *PrivateService) logvalue_Federation_PostArgument(v *PrivateService_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1837,7 +1868,7 @@ func (s *PrivateService) logvalue_Federation_Reaction(v *Reaction) slog.Value {
 	)
 }
 
-func (s *PrivateService) logvalue_Federation_ReactionArgument(v *Federation_ReactionArgument) slog.Value {
+func (s *PrivateService) logvalue_Federation_ReactionArgument(v *PrivateService_Federation_ReactionArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1856,7 +1887,7 @@ func (s *PrivateService) logvalue_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *PrivateService) logvalue_Federation_UserArgument(v *Federation_UserArgument) slog.Value {
+func (s *PrivateService) logvalue_Federation_UserArgument(v *PrivateService_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1864,6 +1895,17 @@ func (s *PrivateService) logvalue_Federation_UserArgument(v *Federation_UserArgu
 		slog.String("id", v.Id),
 		slog.String("name", v.Name),
 	)
+}
+
+// Federation_GetStatusResponseArgument is argument for "federation.GetStatusResponse" message.
+type DebugService_Federation_GetStatusResponseArgument struct {
+	U *User
+}
+
+// Federation_UserArgument is argument for "federation.User" message.
+type DebugService_Federation_UserArgument struct {
+	Id   string
+	Name string
 }
 
 // DebugServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -1969,7 +2011,7 @@ func (s *DebugService) GetStatus(ctx context.Context, req *GetStatusRequest) (re
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetStatusResponse(ctx, &Federation_GetStatusResponseArgument{})
+	res, err := s.resolve_Federation_GetStatusResponse(ctx, &DebugService_Federation_GetStatusResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -1979,7 +2021,7 @@ func (s *DebugService) GetStatus(ctx context.Context, req *GetStatusRequest) (re
 }
 
 // resolve_Federation_GetStatusResponse resolve "federation.GetStatusResponse" message.
-func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context, req *Federation_GetStatusResponseArgument) (*GetStatusResponse, error) {
+func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context, req *DebugService_Federation_GetStatusResponseArgument) (*GetStatusResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetStatusResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -2019,7 +2061,7 @@ func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context,
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_UserArgument{}
+			args := &DebugService_Federation_UserArgument{}
 			// { name: "id", by: "'xxxx'" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -2080,7 +2122,7 @@ func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context,
 }
 
 // resolve_Federation_User resolve "federation.User" message.
-func (s *DebugService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
+func (s *DebugService) resolve_Federation_User(ctx context.Context, req *DebugService_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -2144,7 +2186,7 @@ func (s *DebugService) logvalue_Federation_GetStatusResponse(v *GetStatusRespons
 	)
 }
 
-func (s *DebugService) logvalue_Federation_GetStatusResponseArgument(v *Federation_GetStatusResponseArgument) slog.Value {
+func (s *DebugService) logvalue_Federation_GetStatusResponseArgument(v *DebugService_Federation_GetStatusResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -2161,7 +2203,7 @@ func (s *DebugService) logvalue_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *DebugService) logvalue_Federation_UserArgument(v *Federation_UserArgument) slog.Value {
+func (s *DebugService) logvalue_Federation_UserArgument(v *DebugService_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/11_multi_service/federation/other_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/other_grpc_federation.pb.go
@@ -26,14 +26,34 @@ var (
 )
 
 // Federation_GetResponseArgument is argument for "federation.GetResponse" message.
-type Federation_GetResponseArgument struct {
+type OtherService_Federation_GetResponseArgument struct {
 	Id string
 	P  *Post
 }
 
 // Federation_GetResponse_PostArgument is custom resolver's argument for "post" field of "federation.GetResponse" message.
-type Federation_GetResponse_PostArgument struct {
-	*Federation_GetResponseArgument
+type OtherService_Federation_GetResponse_PostArgument struct {
+	*OtherService_Federation_GetResponseArgument
+}
+
+// Federation_PostArgument is argument for "federation.Post" message.
+type OtherService_Federation_PostArgument struct {
+	Cmp           bool
+	FavoriteValue favorite.FavoriteType
+	Reaction      *Reaction
+	U             *User
+}
+
+// Federation_ReactionArgument is argument for "federation.Reaction" message.
+type OtherService_Federation_ReactionArgument struct {
+	Cmp bool
+	V   favorite.FavoriteType
+}
+
+// Federation_UserArgument is argument for "federation.User" message.
+type OtherService_Federation_UserArgument struct {
+	Id   string
+	Name string
 }
 
 // OtherServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -67,7 +87,7 @@ type OtherServiceDependentClientSet struct {
 // OtherServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type OtherServiceResolver interface {
 	// Resolve_Federation_GetResponse_Post implements resolver for "federation.GetResponse.post".
-	Resolve_Federation_GetResponse_Post(context.Context, *Federation_GetResponse_PostArgument) (*Post, error)
+	Resolve_Federation_GetResponse_Post(context.Context, *OtherService_Federation_GetResponse_PostArgument) (*Post, error)
 }
 
 // OtherServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -85,7 +105,7 @@ type OtherServiceUnimplementedResolver struct{}
 
 // Resolve_Federation_GetResponse_Post resolve "federation.GetResponse.post".
 // This method always returns Unimplemented error.
-func (OtherServiceUnimplementedResolver) Resolve_Federation_GetResponse_Post(context.Context, *Federation_GetResponse_PostArgument) (ret *Post, e error) {
+func (OtherServiceUnimplementedResolver) Resolve_Federation_GetResponse_Post(context.Context, *OtherService_Federation_GetResponse_PostArgument) (ret *Post, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Federation_GetResponse_Post not implemented")
 	return
 }
@@ -162,7 +182,7 @@ func (s *OtherService) Get(ctx context.Context, req *GetRequest) (res *GetRespon
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetResponse(ctx, &Federation_GetResponseArgument{
+	res, err := s.resolve_Federation_GetResponse(ctx, &OtherService_Federation_GetResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -174,7 +194,7 @@ func (s *OtherService) Get(ctx context.Context, req *GetRequest) (res *GetRespon
 }
 
 // resolve_Federation_GetResponse resolve "federation.GetResponse" message.
-func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *OtherService_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -210,7 +230,7 @@ func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_PostArgument{}
+			args := &OtherService_Federation_PostArgument{}
 			return s.resolve_Federation_Post(ctx, args)
 		},
 	}); err != nil {
@@ -229,8 +249,8 @@ func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.Post, err = s.resolver.Resolve_Federation_GetResponse_Post(ctx, &Federation_GetResponse_PostArgument{
-			Federation_GetResponseArgument: req,
+		ret.Post, err = s.resolver.Resolve_Federation_GetResponse_Post(ctx, &OtherService_Federation_GetResponse_PostArgument{
+			OtherService_Federation_GetResponseArgument: req,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -243,7 +263,7 @@ func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *
 }
 
 // resolve_Federation_Post resolve "federation.Post" message.
-func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
+func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *OtherService_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -364,7 +384,7 @@ func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *Federat
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_ReactionArgument{}
+				args := &OtherService_Federation_ReactionArgument{}
 				// { name: "v", by: "favorite_value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[favorite.FavoriteType]{
 					Value:             value,
@@ -410,7 +430,7 @@ func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *Federat
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Federation_UserArgument{}
+				args := &OtherService_Federation_UserArgument{}
 				// { name: "id", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -568,7 +588,7 @@ func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *Federat
 }
 
 // resolve_Federation_Reaction resolve "federation.Reaction" message.
-func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *Federation_ReactionArgument) (*Reaction, error) {
+func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *OtherService_Federation_ReactionArgument) (*Reaction, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Reaction")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -664,7 +684,7 @@ func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *Fed
 }
 
 // resolve_Federation_User resolve "federation.User" message.
-func (s *OtherService) resolve_Federation_User(ctx context.Context, req *Federation_UserArgument) (*User, error) {
+func (s *OtherService) resolve_Federation_User(ctx context.Context, req *OtherService_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -757,7 +777,7 @@ func (s *OtherService) logvalue_Federation_GetResponse(v *GetResponse) slog.Valu
 	)
 }
 
-func (s *OtherService) logvalue_Federation_GetResponseArgument(v *Federation_GetResponseArgument) slog.Value {
+func (s *OtherService) logvalue_Federation_GetResponseArgument(v *OtherService_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -791,7 +811,7 @@ func (s *OtherService) logvalue_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *OtherService) logvalue_Federation_PostArgument(v *Federation_PostArgument) slog.Value {
+func (s *OtherService) logvalue_Federation_PostArgument(v *OtherService_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -809,7 +829,7 @@ func (s *OtherService) logvalue_Federation_Reaction(v *Reaction) slog.Value {
 	)
 }
 
-func (s *OtherService) logvalue_Federation_ReactionArgument(v *Federation_ReactionArgument) slog.Value {
+func (s *OtherService) logvalue_Federation_ReactionArgument(v *OtherService_Federation_ReactionArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -828,7 +848,7 @@ func (s *OtherService) logvalue_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *OtherService) logvalue_Federation_UserArgument(v *Federation_UserArgument) slog.Value {
+func (s *OtherService) logvalue_Federation_UserArgument(v *OtherService_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/11_multi_service/federation/reaction_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/reaction_grpc_federation.pb.go
@@ -8,16 +8,8 @@ package federation
 
 import (
 	"reflect"
-
-	favorite "example/favorite"
 )
 
 var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
-
-// Federation_ReactionArgument is argument for "federation.Reaction" message.
-type Federation_ReactionArgument struct {
-	Cmp bool
-	V   favorite.FavoriteType
-}

--- a/_examples/11_multi_service/main_test.go
+++ b/_examples/11_multi_service/main_test.go
@@ -34,7 +34,7 @@ var otherServicePostData = &federation.Post{
 	},
 }
 
-func (r *Resolver) Resolve_Federation_GetResponse_Post(_ context.Context, _ *federation.Federation_GetResponse_PostArgument) (*federation.Post, error) {
+func (r *Resolver) Resolve_Federation_GetResponse_Post(_ context.Context, _ *federation.OtherService_Federation_GetResponse_PostArgument) (*federation.Post, error) {
 	return otherServicePostData, nil
 }
 

--- a/_examples/12_validation/federation/federation_grpc_federation.pb.go
+++ b/_examples/12_validation/federation/federation_grpc_federation.pb.go
@@ -23,17 +23,17 @@ var (
 )
 
 // Org_Federation_CustomHandlerMessageArgument is argument for "org.federation.CustomHandlerMessage" message.
-type Org_Federation_CustomHandlerMessageArgument struct {
+type FederationService_Org_Federation_CustomHandlerMessageArgument struct {
 	Arg string
 }
 
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
-type Org_Federation_CustomMessageArgument struct {
+type FederationService_Org_Federation_CustomMessageArgument struct {
 	Message string
 }
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Condition           bool
 	Id                  string
 	Post                *Post
@@ -42,7 +42,7 @@ type Org_Federation_GetPostResponseArgument struct {
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -76,7 +76,7 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_CustomHandlerMessage implements resolver for "org.federation.CustomHandlerMessage".
-	Resolve_Org_Federation_CustomHandlerMessage(context.Context, *Org_Federation_CustomHandlerMessageArgument) (*CustomHandlerMessage, error)
+	Resolve_Org_Federation_CustomHandlerMessage(context.Context, *FederationService_Org_Federation_CustomHandlerMessageArgument) (*CustomHandlerMessage, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -94,7 +94,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_CustomHandlerMessage resolve "org.federation.CustomHandlerMessage".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_CustomHandlerMessage(context.Context, *Org_Federation_CustomHandlerMessageArgument) (ret *CustomHandlerMessage, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_CustomHandlerMessage(context.Context, *FederationService_Org_Federation_CustomHandlerMessageArgument) (ret *CustomHandlerMessage, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_CustomHandlerMessage not implemented")
 	return
 }
@@ -167,7 +167,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -179,7 +179,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_CustomHandlerMessage resolve "org.federation.CustomHandlerMessage" message.
-func (s *FederationService) resolve_Org_Federation_CustomHandlerMessage(ctx context.Context, req *Org_Federation_CustomHandlerMessageArgument) (*CustomHandlerMessage, error) {
+func (s *FederationService) resolve_Org_Federation_CustomHandlerMessage(ctx context.Context, req *FederationService_Org_Federation_CustomHandlerMessageArgument) (*CustomHandlerMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomHandlerMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -253,7 +253,7 @@ func (s *FederationService) resolve_Org_Federation_CustomHandlerMessage(ctx cont
 }
 
 // resolve_Org_Federation_CustomMessage resolve "org.federation.CustomMessage" message.
-func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
+func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *FederationService_Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -295,7 +295,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -355,7 +355,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				return s.resolve_Org_Federation_Post(ctx, args)
 			},
 		}); err != nil {
@@ -436,7 +436,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				return s.resolve_Org_Federation_Post(ctx, args)
 			},
 		}); err != nil {
@@ -517,7 +517,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				return s.resolve_Org_Federation_Post(ctx, args)
 			},
 		}); err != nil {
@@ -636,7 +636,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 												return nil
 											},
 											Message: func(ctx context.Context, value *localValueType) (any, error) {
-												args := &Org_Federation_CustomMessageArgument{}
+												args := &FederationService_Org_Federation_CustomMessageArgument{}
 												// { name: "message", by: "'message1'" }
 												if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 													Value:             value,
@@ -679,7 +679,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 												return nil
 											},
 											Message: func(ctx context.Context, value *localValueType) (any, error) {
-												args := &Org_Federation_CustomMessageArgument{}
+												args := &FederationService_Org_Federation_CustomMessageArgument{}
 												// { name: "message", by: "'message2'" }
 												if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 													Value:             value,
@@ -807,7 +807,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				return s.resolve_Org_Federation_Post(ctx, args)
 			},
 		}); err != nil {
@@ -916,7 +916,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_CustomHandlerMessageArgument{}
+				args := &FederationService_Org_Federation_CustomHandlerMessageArgument{}
 				// { name: "arg", by: "'some-arg'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -973,7 +973,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1049,7 +1049,7 @@ func (s *FederationService) logvalue_Org_Federation_CustomHandlerMessage(v *Cust
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Org_Federation_CustomHandlerMessageArgument(v *Org_Federation_CustomHandlerMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CustomHandlerMessageArgument(v *FederationService_Org_Federation_CustomHandlerMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1067,7 +1067,7 @@ func (s *FederationService) logvalue_Org_Federation_CustomMessage(v *CustomMessa
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *Org_Federation_CustomMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *FederationService_Org_Federation_CustomMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1085,7 +1085,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1105,7 +1105,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/12_validation/main_test.go
+++ b/_examples/12_validation/main_test.go
@@ -20,7 +20,7 @@ import (
 
 type Resolver struct{}
 
-func (r *Resolver) Resolve_Org_Federation_CustomHandlerMessage(_ context.Context, _ *federation.Org_Federation_CustomHandlerMessageArgument) (*federation.CustomHandlerMessage, error) {
+func (r *Resolver) Resolve_Org_Federation_CustomHandlerMessage(_ context.Context, _ *federation.FederationService_Org_Federation_CustomHandlerMessageArgument) (*federation.CustomHandlerMessage, error) {
 	return &federation.CustomHandlerMessage{}, nil
 }
 

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -26,13 +26,13 @@ var (
 )
 
 // Org_Federation_GetPostsResponseArgument is argument for "org.federation.GetPostsResponse" message.
-type Org_Federation_GetPostsResponseArgument struct {
+type FederationService_Org_Federation_GetPostsResponseArgument struct {
 	Ids   []string
 	Posts *Posts
 }
 
 // Org_Federation_PostsArgument is argument for "org.federation.Posts" message.
-type Org_Federation_PostsArgument struct {
+type FederationService_Org_Federation_PostsArgument struct {
 	Ids     []string
 	Items   []*Posts_PostItem
 	PostIds []string
@@ -42,12 +42,12 @@ type Org_Federation_PostsArgument struct {
 }
 
 // Org_Federation_Posts_PostItemArgument is argument for "org.federation.PostItem" message.
-type Org_Federation_Posts_PostItemArgument struct {
+type FederationService_Org_Federation_Posts_PostItemArgument struct {
 	Id string
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Res    *user.GetUserResponse
 	User   *user.User
 	UserId string
@@ -193,7 +193,7 @@ func (s *FederationService) GetPosts(ctx context.Context, req *GetPostsRequest) 
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostsResponse(ctx, &Org_Federation_GetPostsResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostsResponse(ctx, &FederationService_Org_Federation_GetPostsResponseArgument{
 		Ids: req.GetIds(),
 	})
 	if err != nil {
@@ -205,7 +205,7 @@ func (s *FederationService) GetPosts(ctx context.Context, req *GetPostsRequest) 
 }
 
 // resolve_Org_Federation_GetPostsResponse resolve "org.federation.GetPostsResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.Context, req *Org_Federation_GetPostsResponseArgument) (*GetPostsResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostsResponseArgument) (*GetPostsResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostsResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -242,7 +242,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostsArgument{}
+			args := &FederationService_Org_Federation_PostsArgument{}
 			// { name: "post_ids", by: "$.ids" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[[]string]{
 				Value:             value,
@@ -290,7 +290,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 }
 
 // resolve_Org_Federation_Posts resolve "org.federation.Posts" message.
-func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, req *Org_Federation_PostsArgument) (*Posts, error) {
+func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, req *FederationService_Org_Federation_PostsArgument) (*Posts, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -524,7 +524,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 			IteratorType:   grpcfed.CELObjectType("post.Post"),
 			IteratorSource: func(value *localValueType) []*post.Post { return value.vars.posts },
 			Iterator: func(ctx context.Context, value *grpcfed.MapIteratorValue) (any, error) {
-				args := &Org_Federation_Posts_PostItemArgument{}
+				args := &FederationService_Org_Federation_Posts_PostItemArgument{}
 				// { name: "id", by: "iter.id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -640,7 +640,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 			IteratorType:   grpcfed.CELObjectType("post.Post"),
 			IteratorSource: func(value *localValueType) []*post.Post { return value.vars.posts },
 			Iterator: func(ctx context.Context, value *grpcfed.MapIteratorValue) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "iter.user_id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -754,7 +754,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 }
 
 // resolve_Org_Federation_Posts_PostItem resolve "org.federation.Posts.PostItem" message.
-func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Context, req *Org_Federation_Posts_PostItemArgument) (*Posts_PostItem, error) {
+func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Context, req *FederationService_Org_Federation_Posts_PostItemArgument) (*Posts_PostItem, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts.PostItem")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -796,7 +796,7 @@ func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Co
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -905,7 +905,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostsResponse(v *GetPosts
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostsResponseArgument(v *Org_Federation_GetPostsResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostsResponseArgument(v *FederationService_Org_Federation_GetPostsResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -927,7 +927,7 @@ func (s *FederationService) logvalue_Org_Federation_Posts(v *Posts) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostsArgument(v *Org_Federation_PostsArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostsArgument(v *FederationService_Org_Federation_PostsArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -945,7 +945,7 @@ func (s *FederationService) logvalue_Org_Federation_Posts_PostItem(v *Posts_Post
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_Posts_PostItemArgument(v *Org_Federation_Posts_PostItemArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_Posts_PostItemArgument(v *FederationService_Org_Federation_Posts_PostItemArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -964,7 +964,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -25,13 +25,13 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id    string
 	Post  *post.Post
 	Posts []*post.Post
@@ -41,7 +41,7 @@ type Org_Federation_PostArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	UserId string
 }
 
@@ -170,7 +170,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -182,7 +182,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -219,7 +219,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -267,7 +267,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -485,7 +485,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "post.user_id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -542,7 +542,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 		IteratorType:   grpcfed.CELObjectType("post.Post"),
 		IteratorSource: func(value *localValueType) []*post.Post { return value.vars.posts },
 		Iterator: func(ctx context.Context, value *grpcfed.MapIteratorValue) (any, error) {
-			args := &Org_Federation_UserArgument{}
+			args := &FederationService_Org_Federation_UserArgument{}
 			// { name: "user_id", by: "iter.user_id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -667,7 +667,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -717,7 +717,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -737,7 +737,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -755,7 +755,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
@@ -25,7 +25,7 @@ var (
 )
 
 // Org_Federation_IsMatchResponseArgument is argument for "org.federation.IsMatchResponse" message.
-type Org_Federation_IsMatchResponseArgument struct {
+type FederationService_Org_Federation_IsMatchResponseArgument struct {
 	Expr    string
 	Matched bool
 	Re      *pluginpb.Regexp
@@ -180,7 +180,7 @@ func (s *FederationService) IsMatch(ctx context.Context, req *IsMatchRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_IsMatchResponse(ctx, &Org_Federation_IsMatchResponseArgument{
+	res, err := s.resolve_Org_Federation_IsMatchResponse(ctx, &FederationService_Org_Federation_IsMatchResponseArgument{
 		Expr:   req.GetExpr(),
 		Target: req.GetTarget(),
 	})
@@ -193,7 +193,7 @@ func (s *FederationService) IsMatch(ctx context.Context, req *IsMatchRequest) (r
 }
 
 // resolve_Org_Federation_IsMatchResponse resolve "org.federation.IsMatchResponse" message.
-func (s *FederationService) resolve_Org_Federation_IsMatchResponse(ctx context.Context, req *Org_Federation_IsMatchResponseArgument) (*IsMatchResponse, error) {
+func (s *FederationService) resolve_Org_Federation_IsMatchResponse(ctx context.Context, req *FederationService_Org_Federation_IsMatchResponseArgument) (*IsMatchResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.IsMatchResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -293,7 +293,7 @@ func (s *FederationService) logvalue_Org_Federation_IsMatchResponse(v *IsMatchRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_IsMatchResponseArgument(v *Org_Federation_IsMatchResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_IsMatchResponseArgument(v *FederationService_Org_Federation_IsMatchResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/16_code_gen_plugin/cmd/plugin/resolver.go.tmpl
+++ b/_examples/16_code_gen_plugin/cmd/plugin/resolver.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"example/federation"
 )
 
-func (r *resolver) Resolve_Org_Federation_GetResponse(ctx context.Context, req *federation.Org_Federation_GetResponseArgument) (*federation.GetResponse, error) {
+func (r *resolver) Resolve_Org_Federation_GetResponse(ctx context.Context, req *federation.FederationService_Org_Federation_GetResponseArgument) (*federation.GetResponse, error) {
 	return &federation.GetResponse{
 		Id: req.Id,
 	}, nil

--- a/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
@@ -23,7 +23,7 @@ var (
 )
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	Id int64
 }
 
@@ -58,7 +58,7 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_GetResponse implements resolver for "org.federation.GetResponse".
-	Resolve_Org_Federation_GetResponse(context.Context, *Org_Federation_GetResponseArgument) (*GetResponse, error)
+	Resolve_Org_Federation_GetResponse(context.Context, *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -76,7 +76,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_GetResponse(context.Context, *Org_Federation_GetResponseArgument) (ret *GetResponse, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_GetResponse(context.Context, *FederationService_Org_Federation_GetResponseArgument) (ret *GetResponse, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_GetResponse not implemented")
 	return
 }
@@ -143,7 +143,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 		}
 	}()
 	res, err := grpcfed.WithTimeout[GetResponse](ctx, "org.federation.FederationService/Get", 10000000000 /* 10s */, func(ctx context.Context) (*GetResponse, error) {
-		return s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{
+		return s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{
 			Id: req.GetId(),
 		})
 	})
@@ -156,7 +156,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -185,7 +185,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/16_code_gen_plugin/resolver_test.go
+++ b/_examples/16_code_gen_plugin/resolver_test.go
@@ -7,7 +7,7 @@ import (
 	"example/federation"
 )
 
-func (r *resolver) Resolve_Org_Federation_GetResponse(ctx context.Context, req *federation.Org_Federation_GetResponseArgument) (*federation.GetResponse, error) {
+func (r *resolver) Resolve_Org_Federation_GetResponse(ctx context.Context, req *federation.FederationService_Org_Federation_GetResponseArgument) (*federation.GetResponse, error) {
 	return &federation.GetResponse{
 		Id: req.Id,
 	}, nil

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -25,23 +25,23 @@ var (
 )
 
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
-type Org_Federation_CustomMessageArgument struct {
+type FederationService_Org_Federation_CustomMessageArgument struct {
 	ErrorInfo *grpcfedcel.Error
 }
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_LocalizedMessageArgument is argument for "org.federation.LocalizedMessage" message.
-type Org_Federation_LocalizedMessageArgument struct {
+type FederationService_Org_Federation_LocalizedMessageArgument struct {
 	Value string
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id                  string
 	LocalizedMsg        *LocalizedMessage
 	Post                *post.Post
@@ -177,7 +177,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -189,7 +189,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_CustomMessage resolve "org.federation.CustomMessage" message.
-func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
+func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *FederationService_Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -231,7 +231,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -268,7 +268,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -316,7 +316,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_LocalizedMessage resolve "org.federation.LocalizedMessage" message.
-func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.Context, req *Org_Federation_LocalizedMessageArgument) (*LocalizedMessage, error) {
+func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.Context, req *FederationService_Org_Federation_LocalizedMessageArgument) (*LocalizedMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.LocalizedMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -358,7 +358,7 @@ func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -480,7 +480,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 								return nil
 							},
 							Message: func(ctx context.Context, value *localValueType) (any, error) {
-								args := &Org_Federation_LocalizedMessageArgument{}
+								args := &FederationService_Org_Federation_LocalizedMessageArgument{}
 								// { name: "value", by: "id" }
 								if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 									Value:             value,
@@ -530,7 +530,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 										return nil
 									},
 									Message: func(ctx context.Context, value *localValueType) (any, error) {
-										args := &Org_Federation_CustomMessageArgument{}
+										args := &FederationService_Org_Federation_CustomMessageArgument{}
 										// { name: "error_info", by: "error" }
 										if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*grpcfedcel.Error]{
 											Value:             value,
@@ -746,7 +746,7 @@ func (s *FederationService) logvalue_Org_Federation_CustomMessage(v *CustomMessa
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *Org_Federation_CustomMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *FederationService_Org_Federation_CustomMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -764,7 +764,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -782,7 +782,7 @@ func (s *FederationService) logvalue_Org_Federation_LocalizedMessage(v *Localize
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_LocalizedMessageArgument(v *Org_Federation_LocalizedMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_LocalizedMessageArgument(v *FederationService_Org_Federation_LocalizedMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -801,7 +801,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/18_load/federation/federation_grpc_federation.pb.go
+++ b/_examples/18_load/federation/federation_grpc_federation.pb.go
@@ -23,7 +23,7 @@ var (
 )
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	IdFromMetadata string
 	IdFromPlugin   string
 }
@@ -170,7 +170,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -180,7 +180,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -313,7 +313,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -25,12 +25,12 @@ var (
 )
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type Federation_GetPostResponseArgument struct {
+type FederationService_Federation_GetPostResponseArgument struct {
 	Id string
 }
 
 // Federation_PostArgument is argument for "federation.Post" message.
-type Federation_PostArgument struct {
+type FederationService_Federation_PostArgument struct {
 	Id string
 }
 
@@ -156,7 +156,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Federation_GetPostResponse(ctx, &Federation_GetPostResponseArgument{
+	res, err := s.resolve_Federation_GetPostResponse(ctx, &FederationService_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -168,7 +168,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Federation_GetPostResponse resolve "federation.GetPostResponse" message.
-func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Context, req *FederationService_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -205,7 +205,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Federation_PostArgument{}
+			args := &FederationService_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -234,7 +234,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 }
 
 // resolve_Federation_Post resolve "federation.Post" message.
-func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *FederationService_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -323,7 +323,7 @@ func (s *FederationService) logvalue_Federation_GetPostResponse(v *GetPostRespon
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_GetPostResponseArgument(v *FederationService_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -339,7 +339,7 @@ func (s *FederationService) logvalue_Federation_Post(v *Post) slog.Value {
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Federation_PostArgument(v *Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Federation_PostArgument(v *FederationService_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/code_generator.go
+++ b/generator/code_generator.go
@@ -535,14 +535,6 @@ func newServiceTypeDeclares(file *File, msgs []*resolver.Message) []*Type {
 	return ret
 }
 
-func newTypeDeclares(file *File, msg *resolver.Message) []*Type {
-	ret := newTypeDeclaresWithMessage(file, msg)
-	for _, msg := range msg.NestedMessages {
-		ret = append(ret, newTypeDeclares(file, msg)...)
-	}
-	return ret
-}
-
 func newTypeDeclaresWithMessage(file *File, msg *resolver.Message) []*Type {
 	if !msg.HasRule() {
 		return nil

--- a/generator/code_generator.go
+++ b/generator/code_generator.go
@@ -524,21 +524,6 @@ func (f *File) Enums() []*Enum {
 	return ret
 }
 
-func (f *File) Types() Types {
-	return newFileTypeDeclares(f, f.Messages)
-}
-
-func newFileTypeDeclares(file *File, msgs []*resolver.Message) []*Type {
-	var ret []*Type
-	for _, msg := range msgs {
-		ret = append(ret, newTypeDeclares(file, msg)...)
-	}
-	sort.Slice(ret, func(i, j int) bool {
-		return ret[i].Name < ret[j].Name
-	})
-	return ret
-}
-
 func newServiceTypeDeclares(file *File, msgs []*resolver.Message) []*Type {
 	var ret []*Type
 	for _, msg := range msgs {
@@ -626,7 +611,7 @@ func newTypeDeclaresWithMessage(file *File, msg *resolver.Message) []*Type {
 	declTypes := []*Type{typ}
 	for _, field := range msg.CustomResolverFields() {
 		typeName := fmt.Sprintf("%s_%sArgument", msgName, util.ToPublicGoVariable(field.Name))
-		fields := []*Field{{Type: fmt.Sprintf("*%s", argName)}}
+		fields := []*Field{{Type: argName}}
 		if msg.HasCustomResolver() {
 			fields = append(fields, &Field{
 				Name: msgName,
@@ -1179,7 +1164,7 @@ func (s *Service) setLogValueByMessageArgument(msg *resolver.Message) {
 	}
 	logValue := &LogValue{
 		Name:      name,
-		ValueType: "*" + protoFQDNToPublicGoName(arg.FQDN()),
+		ValueType: "*" + s.ServiceName() + "_" + protoFQDNToPublicGoName(arg.FQDN()),
 		Attrs:     make([]*LogValueAttr, 0, len(arg.Fields)),
 		Type:      resolver.NewMessageType(arg, false),
 	}
@@ -1481,7 +1466,7 @@ func (m *Method) ResolverName() string {
 
 func (m *Method) ArgumentName() string {
 	msg := fullMessageName(m.Response)
-	return fmt.Sprintf("%sArgument", msg)
+	return fmt.Sprintf("%s_%sArgument", m.Service.ServiceName(), msg)
 }
 
 func (m *Method) RequestType() string {
@@ -2851,7 +2836,7 @@ func (d *VariableDefinition) RequestType() string {
 		)
 	case expr.Message != nil:
 		msgName := fullMessageName(expr.Message.Message)
-		return fmt.Sprintf("%sArgument", msgName)
+		return fmt.Sprintf("%s_%sArgument", d.ServiceName(), msgName)
 	}
 	return ""
 }

--- a/generator/templates/eval.go.tmpl
+++ b/generator/templates/eval.go.tmpl
@@ -30,7 +30,7 @@ grpcfed.EvalDefMap({{ $ctx }}, value, grpcfed.DefMap[{{ $def.Type }}, {{ $mapRes
 		})
 		{{- else if $mapResolver.IsMessage }}
 		{{- $arguments := $mapResolver.Arguments }}
-		args := &{{ $mapResolver.RequestType }}{
+		args := &{{ $mapResolver.Service.ServiceName }}_{{ $mapResolver.RequestType }}{
 			{{- range $arguments }}
 			{{- if not .CEL }}
 			{{ .Name }}: {{ .Value }}, {{ .ProtoComment }}

--- a/generator/templates/server.go.tmpl
+++ b/generator/templates/server.go.tmpl
@@ -26,21 +26,6 @@ var (
 )
 
 {{- $pkgName := .Package.Name }}
-{{- range .Types }}
-
-// {{ .Desc }}.
-type {{ .Name }} struct {
-	{{- range .Fields }}
-	{{- if .Name }}
-	{{ .Name }} {{ .Type }}
-	{{- else }}
-	{{ .Type }}
-	{{- end }}
-	{{- end }}
-}
-
-{{- end }}
-
 {{- $enums := .Enums }}
 
 {{- range .Services }}
@@ -52,6 +37,21 @@ type {{ .Name }} struct {
 {{- $oneofTypes := .OneofTypes }}
 {{- $celPlugins := .CELPlugins }}
 {{- $env := .Env }}
+
+{{- range $types }}
+
+// {{ .Desc }}.
+type {{ $serviceName }}_{{ .Name }} struct {
+	{{- range .Fields }}
+	{{- if .Name }}
+	{{ .Name }} {{ .Type }}
+	{{- else }}
+	*{{ $serviceName }}_{{ .Type }}
+	{{- end }}
+	{{- end }}
+}
+
+{{- end }}
 
 // {{ $serviceName }}Config configuration required to initialize the service that use GRPC Federation.
 type {{ $serviceName }}Config struct {
@@ -105,7 +105,7 @@ type {{ $serviceName }}DependentClientSet struct {
 type {{ $serviceName }}Resolver interface {
 	{{- range $customResolvers }}
 	// {{ .Name }} implements resolver for "{{ .ProtoFQDN }}".
-	{{ .Name }}(context.Context, *{{ .RequestType }}) ({{ .ReturnType }}, error)
+	{{ .Name }}(context.Context, *{{ $serviceName }}_{{ .RequestType }}) ({{ .ReturnType }}, error)
 	{{- end }}
 }
 
@@ -152,7 +152,7 @@ type {{ $serviceName }}UnimplementedResolver struct {}
 {{- range $customResolvers }}
 // {{ .Name }} resolve "{{ .ProtoFQDN }}".
 // This method always returns Unimplemented error.
-func ({{ $serviceName }}UnimplementedResolver) {{ .Name }}(context.Context, *{{ .RequestType }}) (ret {{ .ReturnType }}, e error) {
+func ({{ $serviceName }}UnimplementedResolver) {{ .Name }}(context.Context, *{{ $serviceName }}_{{ .RequestType }}) (ret {{ .ReturnType }}, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method {{ .Name }} not implemented")
 	return
 }
@@ -378,7 +378,7 @@ func (s *{{ $serviceName }}) {{ .Name }}(ctx context.Context, req {{ .RequestTyp
 {{- $hasCELValue := .HasCELValue }}
 {{ if .HasRule }}
 // {{ .ResolverName }} resolve "{{ .ProtoFQDN }}" message.
-func (s *{{ $serviceName }}) {{ .ResolverName }}(ctx context.Context, req *{{ .RequestType }}) (*{{ .ReturnType }}, error) {
+func (s *{{ $serviceName }}) {{ .ResolverName }}(ctx context.Context, req *{{ $serviceName }}_{{ .RequestType }}) (*{{ .ReturnType }}, error) {
 	ctx, span := s.tracer.Start(ctx, "{{ .ProtoFQDN }}")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -435,7 +435,7 @@ func (s *{{ $serviceName }}) {{ .ResolverName }}(ctx context.Context, req *{{ .R
 	{{- end }}
 	{{- range $returnFields }}
 	{{- if .CustomResolver }}
-	{{- template "setReturnValueByFieldCustomResolver" (map "HasMsgCustomResolver" $hasMsgCustomResolver "Value" .CustomResolver) }}
+	{{- template "setReturnValueByFieldCustomResolver" (map "HasMsgCustomResolver" $hasMsgCustomResolver "Value" .CustomResolver "ServiceName" $serviceName) }}
 	{{- else if .Oneof }}
 	{{- template "setReturnValueByOneofFields" (map "Message" $msg "Value" .Oneof) }}
 	{{- else if .CEL }}
@@ -532,8 +532,8 @@ func (s *{{ $serviceName }}) {{ .Name }}(v {{ .ValueType }}) slog.Value {
 	// (grpc.federation.field).custom_resolver = true
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 	var err error
-	ret.{{ $value.Name }}, err = s.resolver.{{ $value.ResolverName }}(ctx, &{{ $value.RequestType }}{
-		{{ $value.MessageArgumentName }}: req,
+	ret.{{ $value.Name }}, err = s.resolver.{{ $value.ResolverName }}(ctx, &{{ .ServiceName }}_{{ $value.RequestType }}{
+		{{ .ServiceName }}_{{ $value.MessageArgumentName }}: req,
 		{{- if $hasMsgCustomResolver }}
 		{{ $value.MessageName }}: ret,
 		{{- end }}

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -24,16 +24,8 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostRequest_ConditionAArgument is argument for "org.federation.ConditionA" message.
-type Org_Federation_GetPostRequest_ConditionAArgument struct {
-}
-
-// Org_Federation_GetPostRequest_ConditionBArgument is argument for "org.federation.ConditionB" message.
-type Org_Federation_GetPostRequest_ConditionBArgument struct {
-}
-
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	A    *GetPostRequest_ConditionA
 	B    *GetPostRequest_ConditionB
 	Id   string
@@ -41,20 +33,12 @@ type Org_Federation_GetPostResponseArgument struct {
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	A    *GetPostRequest_ConditionA
 	B    *GetPostRequest_ConditionB
 	Id   string
 	Post *post.Post
 	Res  *post.GetPostResponse
-}
-
-// Org_Federation_PostContentArgument is argument for "org.federation.PostContent" message.
-type Org_Federation_PostContentArgument struct {
-}
-
-// Org_Federation_PostDataArgument is argument for "org.federation.PostData" message.
-type Org_Federation_PostDataArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -187,7 +171,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 		A:  req.GetA(),
 		B:  req.GetB(),
@@ -201,7 +185,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -242,7 +226,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -316,7 +300,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -628,7 +612,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -649,7 +633,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_async.go
+++ b/generator/testdata/expected_async.go
@@ -23,49 +23,49 @@ var (
 )
 
 // Org_Federation_AAArgument is argument for "org.federation.AA" message.
-type Org_Federation_AAArgument struct {
+type FederationService_Org_Federation_AAArgument struct {
 }
 
 // Org_Federation_AArgument is argument for "org.federation.A" message.
-type Org_Federation_AArgument struct {
+type FederationService_Org_Federation_AArgument struct {
 }
 
 // Org_Federation_ABArgument is argument for "org.federation.AB" message.
-type Org_Federation_ABArgument struct {
+type FederationService_Org_Federation_ABArgument struct {
 }
 
 // Org_Federation_BArgument is argument for "org.federation.B" message.
-type Org_Federation_BArgument struct {
+type FederationService_Org_Federation_BArgument struct {
 }
 
 // Org_Federation_CArgument is argument for "org.federation.C" message.
-type Org_Federation_CArgument struct {
+type FederationService_Org_Federation_CArgument struct {
 	A string
 }
 
 // Org_Federation_DArgument is argument for "org.federation.D" message.
-type Org_Federation_DArgument struct {
+type FederationService_Org_Federation_DArgument struct {
 	B string
 }
 
 // Org_Federation_EArgument is argument for "org.federation.E" message.
-type Org_Federation_EArgument struct {
+type FederationService_Org_Federation_EArgument struct {
 	C string
 	D string
 }
 
 // Org_Federation_FArgument is argument for "org.federation.F" message.
-type Org_Federation_FArgument struct {
+type FederationService_Org_Federation_FArgument struct {
 	C string
 	D string
 }
 
 // Org_Federation_GArgument is argument for "org.federation.G" message.
-type Org_Federation_GArgument struct {
+type FederationService_Org_Federation_GArgument struct {
 }
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	A *A
 	B *B
 	C *C
@@ -79,18 +79,18 @@ type Org_Federation_GetResponseArgument struct {
 }
 
 // Org_Federation_HArgument is argument for "org.federation.H" message.
-type Org_Federation_HArgument struct {
+type FederationService_Org_Federation_HArgument struct {
 	E string
 	F string
 	G string
 }
 
 // Org_Federation_IArgument is argument for "org.federation.I" message.
-type Org_Federation_IArgument struct {
+type FederationService_Org_Federation_IArgument struct {
 }
 
 // Org_Federation_JArgument is argument for "org.federation.J" message.
-type Org_Federation_JArgument struct {
+type FederationService_Org_Federation_JArgument struct {
 	I string
 }
 
@@ -218,7 +218,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -228,7 +228,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_A resolve "org.federation.A" message.
-func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *Org_Federation_AArgument) (*A, error) {
+func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *FederationService_Org_Federation_AArgument) (*A, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.A")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -273,7 +273,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_AAArgument{}
+				args := &FederationService_Org_Federation_AAArgument{}
 				return s.resolve_Org_Federation_AA(ctx, args)
 			},
 		}); err != nil {
@@ -302,7 +302,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_ABArgument{}
+				args := &FederationService_Org_Federation_ABArgument{}
 				return s.resolve_Org_Federation_AB(ctx, args)
 			},
 		}); err != nil {
@@ -340,7 +340,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_AA resolve "org.federation.AA" message.
-func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *Org_Federation_AAArgument) (*AA, error) {
+func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *FederationService_Org_Federation_AAArgument) (*AA, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AA")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -382,7 +382,7 @@ func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *
 }
 
 // resolve_Org_Federation_AB resolve "org.federation.AB" message.
-func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *Org_Federation_ABArgument) (*AB, error) {
+func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *FederationService_Org_Federation_ABArgument) (*AB, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.AB")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -424,7 +424,7 @@ func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *
 }
 
 // resolve_Org_Federation_B resolve "org.federation.B" message.
-func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *Org_Federation_BArgument) (*B, error) {
+func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *FederationService_Org_Federation_BArgument) (*B, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.B")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -466,7 +466,7 @@ func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_C resolve "org.federation.C" message.
-func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *Org_Federation_CArgument) (*C, error) {
+func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *FederationService_Org_Federation_CArgument) (*C, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.C")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -508,7 +508,7 @@ func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_D resolve "org.federation.D" message.
-func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *Org_Federation_DArgument) (*D, error) {
+func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *FederationService_Org_Federation_DArgument) (*D, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.D")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -550,7 +550,7 @@ func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_E resolve "org.federation.E" message.
-func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *Org_Federation_EArgument) (*E, error) {
+func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *FederationService_Org_Federation_EArgument) (*E, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.E")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -592,7 +592,7 @@ func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_F resolve "org.federation.F" message.
-func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *Org_Federation_FArgument) (*F, error) {
+func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *FederationService_Org_Federation_FArgument) (*F, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.F")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -634,7 +634,7 @@ func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_G resolve "org.federation.G" message.
-func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *Org_Federation_GArgument) (*G, error) {
+func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *FederationService_Org_Federation_GArgument) (*G, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.G")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -676,7 +676,7 @@ func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -745,7 +745,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_AArgument{}
+						args := &FederationService_Org_Federation_AArgument{}
 						return s.resolve_Org_Federation_A(ctx, args)
 					},
 				}); err != nil {
@@ -771,7 +771,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_CArgument{}
+						args := &FederationService_Org_Federation_CArgument{}
 						// { name: "a", by: "a.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -812,7 +812,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_BArgument{}
+						args := &FederationService_Org_Federation_BArgument{}
 						return s.resolve_Org_Federation_B(ctx, args)
 					},
 				}); err != nil {
@@ -838,7 +838,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_DArgument{}
+						args := &FederationService_Org_Federation_DArgument{}
 						// { name: "b", by: "b.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -885,7 +885,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Org_Federation_EArgument{}
+					args := &FederationService_Org_Federation_EArgument{}
 					// { name: "c", by: "c.name" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -941,7 +941,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_AArgument{}
+						args := &FederationService_Org_Federation_AArgument{}
 						return s.resolve_Org_Federation_A(ctx, args)
 					},
 				}); err != nil {
@@ -967,7 +967,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_CArgument{}
+						args := &FederationService_Org_Federation_CArgument{}
 						// { name: "a", by: "a.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -1008,7 +1008,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_BArgument{}
+						args := &FederationService_Org_Federation_BArgument{}
 						return s.resolve_Org_Federation_B(ctx, args)
 					},
 				}); err != nil {
@@ -1034,7 +1034,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 						return nil
 					},
 					Message: func(ctx context.Context, value *localValueType) (any, error) {
-						args := &Org_Federation_DArgument{}
+						args := &FederationService_Org_Federation_DArgument{}
 						// { name: "b", by: "b.name" }
 						if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 							Value:             value,
@@ -1081,7 +1081,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Org_Federation_FArgument{}
+					args := &FederationService_Org_Federation_FArgument{}
 					// { name: "c", by: "c.name" }
 					if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 						Value:             value,
@@ -1135,7 +1135,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 					return nil
 				},
 				Message: func(ctx context.Context, value *localValueType) (any, error) {
-					args := &Org_Federation_GArgument{}
+					args := &FederationService_Org_Federation_GArgument{}
 					return s.resolve_Org_Federation_G(ctx, args)
 				},
 			}); err != nil {
@@ -1170,7 +1170,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_HArgument{}
+				args := &FederationService_Org_Federation_HArgument{}
 				// { name: "e", by: "e.name" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -1238,7 +1238,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_IArgument{}
+				args := &FederationService_Org_Federation_IArgument{}
 				return s.resolve_Org_Federation_I(ctx, args)
 			},
 		}); err != nil {
@@ -1264,7 +1264,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_JArgument{}
+				args := &FederationService_Org_Federation_JArgument{}
 				// { name: "i", by: "i.name" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -1341,7 +1341,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 }
 
 // resolve_Org_Federation_H resolve "org.federation.H" message.
-func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *Org_Federation_HArgument) (*H, error) {
+func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *FederationService_Org_Federation_HArgument) (*H, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.H")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1383,7 +1383,7 @@ func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_I resolve "org.federation.I" message.
-func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *Org_Federation_IArgument) (*I, error) {
+func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *FederationService_Org_Federation_IArgument) (*I, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.I")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1425,7 +1425,7 @@ func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_J resolve "org.federation.J" message.
-func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *Org_Federation_JArgument) (*J, error) {
+func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *FederationService_Org_Federation_JArgument) (*J, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.J")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1484,14 +1484,14 @@ func (s *FederationService) logvalue_Org_Federation_AA(v *AA) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_AAArgument(v *Org_Federation_AAArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_AAArgument(v *FederationService_Org_Federation_AAArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Org_Federation_AArgument(v *Org_Federation_AArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_AArgument(v *FederationService_Org_Federation_AArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1507,7 +1507,7 @@ func (s *FederationService) logvalue_Org_Federation_AB(v *AB) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_ABArgument(v *Org_Federation_ABArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_ABArgument(v *FederationService_Org_Federation_ABArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1523,7 +1523,7 @@ func (s *FederationService) logvalue_Org_Federation_B(v *B) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_BArgument(v *Org_Federation_BArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_BArgument(v *FederationService_Org_Federation_BArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1539,7 +1539,7 @@ func (s *FederationService) logvalue_Org_Federation_C(v *C) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CArgument(v *Org_Federation_CArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CArgument(v *FederationService_Org_Federation_CArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1557,7 +1557,7 @@ func (s *FederationService) logvalue_Org_Federation_D(v *D) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_DArgument(v *Org_Federation_DArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_DArgument(v *FederationService_Org_Federation_DArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1575,7 +1575,7 @@ func (s *FederationService) logvalue_Org_Federation_E(v *E) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_EArgument(v *Org_Federation_EArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_EArgument(v *FederationService_Org_Federation_EArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1594,7 +1594,7 @@ func (s *FederationService) logvalue_Org_Federation_F(v *F) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_FArgument(v *Org_Federation_FArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_FArgument(v *FederationService_Org_Federation_FArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1613,7 +1613,7 @@ func (s *FederationService) logvalue_Org_Federation_G(v *G) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GArgument(v *Org_Federation_GArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GArgument(v *FederationService_Org_Federation_GArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1630,7 +1630,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1646,7 +1646,7 @@ func (s *FederationService) logvalue_Org_Federation_H(v *H) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_HArgument(v *Org_Federation_HArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_HArgument(v *FederationService_Org_Federation_HArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1666,7 +1666,7 @@ func (s *FederationService) logvalue_Org_Federation_I(v *I) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_IArgument(v *Org_Federation_IArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_IArgument(v *FederationService_Org_Federation_IArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1682,7 +1682,7 @@ func (s *FederationService) logvalue_Org_Federation_J(v *J) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_JArgument(v *Org_Federation_JArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_JArgument(v *FederationService_Org_Federation_JArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -25,13 +25,13 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id    string
 	XDef0 *Post
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id    string
 	Res   *post.GetPostResponse
 	XDef1 *post.Post
@@ -39,7 +39,7 @@ type Org_Federation_PostArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	UserId string
 }
 
@@ -169,7 +169,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -219,7 +219,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -256,7 +256,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -374,7 +374,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "'foo'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -420,7 +420,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -472,7 +472,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -493,7 +493,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -511,7 +511,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -25,13 +25,13 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id    string
 	Post  *post.Post
 	Posts []*post.Post
@@ -41,7 +41,7 @@ type Org_Federation_PostArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	UserId string
 }
 
@@ -171,7 +171,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -183,7 +183,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -220,7 +220,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -268,7 +268,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -486,7 +486,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "post.user_id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -543,7 +543,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 		IteratorType:   grpcfed.CELObjectType("org.post.Post"),
 		IteratorSource: func(value *localValueType) []*post.Post { return value.vars.posts },
 		Iterator: func(ctx context.Context, value *grpcfed.MapIteratorValue) (any, error) {
-			args := &Org_Federation_UserArgument{}
+			args := &FederationService_Org_Federation_UserArgument{}
 			// { name: "user_id", by: "iter.user_id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -668,7 +668,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -718,7 +718,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -738,7 +738,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -756,7 +756,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -25,7 +25,7 @@ var (
 )
 
 // Org_Federation_CreatePostArgument is argument for "org.federation.CreatePost" message.
-type Org_Federation_CreatePostArgument struct {
+type FederationService_Org_Federation_CreatePostArgument struct {
 	Content string
 	Title   string
 	Type    PostType
@@ -33,7 +33,7 @@ type Org_Federation_CreatePostArgument struct {
 }
 
 // Org_Federation_CreatePostResponseArgument is argument for "org.federation.CreatePostResponse" message.
-type Org_Federation_CreatePostResponseArgument struct {
+type FederationService_Org_Federation_CreatePostResponseArgument struct {
 	Content string
 	Cp      *CreatePost
 	P       *post.Post
@@ -41,10 +41,6 @@ type Org_Federation_CreatePostResponseArgument struct {
 	Title   string
 	Type    PostType
 	UserId  string
-}
-
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -177,7 +173,7 @@ func (s *FederationService) CreatePost(ctx context.Context, req *CreatePostReque
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_CreatePostResponse(ctx, &Org_Federation_CreatePostResponseArgument{
+	res, err := s.resolve_Org_Federation_CreatePostResponse(ctx, &FederationService_Org_Federation_CreatePostResponseArgument{
 		Title:   req.GetTitle(),
 		Content: req.GetContent(),
 		UserId:  req.GetUserId(),
@@ -192,7 +188,7 @@ func (s *FederationService) CreatePost(ctx context.Context, req *CreatePostReque
 }
 
 // resolve_Org_Federation_CreatePost resolve "org.federation.CreatePost" message.
-func (s *FederationService) resolve_Org_Federation_CreatePost(ctx context.Context, req *Org_Federation_CreatePostArgument) (*CreatePost, error) {
+func (s *FederationService) resolve_Org_Federation_CreatePost(ctx context.Context, req *FederationService_Org_Federation_CreatePostArgument) (*CreatePost, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CreatePost")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -290,7 +286,7 @@ func (s *FederationService) resolve_Org_Federation_CreatePost(ctx context.Contex
 }
 
 // resolve_Org_Federation_CreatePostResponse resolve "org.federation.CreatePostResponse" message.
-func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx context.Context, req *Org_Federation_CreatePostResponseArgument) (*CreatePostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx context.Context, req *FederationService_Org_Federation_CreatePostResponseArgument) (*CreatePostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CreatePostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -334,7 +330,7 @@ func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx contex
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_CreatePostArgument{}
+			args := &FederationService_Org_Federation_CreatePostArgument{}
 			// { name: "title", by: "$.title" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -577,7 +573,7 @@ func (s *FederationService) logvalue_Org_Federation_CreatePost(v *CreatePost) sl
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CreatePostArgument(v *Org_Federation_CreatePostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CreatePostArgument(v *FederationService_Org_Federation_CreatePostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -598,7 +594,7 @@ func (s *FederationService) logvalue_Org_Federation_CreatePostResponse(v *Create
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CreatePostResponseArgument(v *Org_Federation_CreatePostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CreatePostResponseArgument(v *FederationService_Org_Federation_CreatePostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -26,13 +26,13 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id   string
 	Post *post.Post
 	Res  *post.GetPostResponse
@@ -40,12 +40,12 @@ type Org_Federation_PostArgument struct {
 }
 
 // Org_Federation_Post_UserArgument is custom resolver's argument for "user" field of "org.federation.Post" message.
-type Org_Federation_Post_UserArgument struct {
-	*Org_Federation_PostArgument
+type FederationService_Org_Federation_Post_UserArgument struct {
+	*FederationService_Org_Federation_PostArgument
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Content string
 	Id      string
 	Res     *user.GetUserResponse
@@ -55,8 +55,8 @@ type Org_Federation_UserArgument struct {
 }
 
 // Org_Federation_User_NameArgument is custom resolver's argument for "name" field of "org.federation.User" message.
-type Org_Federation_User_NameArgument struct {
-	*Org_Federation_UserArgument
+type FederationService_Org_Federation_User_NameArgument struct {
+	*FederationService_Org_Federation_UserArgument
 	Org_Federation_User *User
 }
 
@@ -100,11 +100,11 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_Post_User implements resolver for "org.federation.Post.user".
-	Resolve_Org_Federation_Post_User(context.Context, *Org_Federation_Post_UserArgument) (*User, error)
+	Resolve_Org_Federation_Post_User(context.Context, *FederationService_Org_Federation_Post_UserArgument) (*User, error)
 	// Resolve_Org_Federation_User implements resolver for "org.federation.User".
-	Resolve_Org_Federation_User(context.Context, *Org_Federation_UserArgument) (*User, error)
+	Resolve_Org_Federation_User(context.Context, *FederationService_Org_Federation_UserArgument) (*User, error)
 	// Resolve_Org_Federation_User_Name implements resolver for "org.federation.User.name".
-	Resolve_Org_Federation_User_Name(context.Context, *Org_Federation_User_NameArgument) (string, error)
+	Resolve_Org_Federation_User_Name(context.Context, *FederationService_Org_Federation_User_NameArgument) (string, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -122,21 +122,21 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_Post_User resolve "org.federation.Post.user".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Post_User(context.Context, *Org_Federation_Post_UserArgument) (ret *User, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Post_User(context.Context, *FederationService_Org_Federation_Post_UserArgument) (ret *User, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_Post_User not implemented")
 	return
 }
 
 // Resolve_Org_Federation_User resolve "org.federation.User".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User(context.Context, *Org_Federation_UserArgument) (ret *User, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User(context.Context, *FederationService_Org_Federation_UserArgument) (ret *User, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_User not implemented")
 	return
 }
 
 // Resolve_Org_Federation_User_Name resolve "org.federation.User.name".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Name(context.Context, *Org_Federation_User_NameArgument) (ret string, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Name(context.Context, *FederationService_Org_Federation_User_NameArgument) (ret string, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_User_Name not implemented")
 	return
 }
@@ -237,7 +237,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -249,7 +249,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -286,7 +286,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -334,7 +334,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -438,7 +438,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_UserArgument{}
+			args := &FederationService_Org_Federation_UserArgument{}
 			// { inline: "post" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*post.Post]{
 				Value:             value,
@@ -478,8 +478,8 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.User, err = s.resolver.Resolve_Org_Federation_Post_User(ctx, &Org_Federation_Post_UserArgument{
-			Org_Federation_PostArgument: req,
+		ret.User, err = s.resolver.Resolve_Org_Federation_Post_User(ctx, &FederationService_Org_Federation_Post_UserArgument{
+			FederationService_Org_Federation_PostArgument: req,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -492,7 +492,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -594,9 +594,9 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.Name, err = s.resolver.Resolve_Org_Federation_User_Name(ctx, &Org_Federation_User_NameArgument{
-			Org_Federation_UserArgument: req,
-			Org_Federation_User:         ret,
+		ret.Name, err = s.resolver.Resolve_Org_Federation_User_Name(ctx, &FederationService_Org_Federation_User_NameArgument{
+			FederationService_Org_Federation_UserArgument: req,
+			Org_Federation_User:                           ret,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -617,7 +617,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -638,7 +638,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -657,7 +657,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -25,23 +25,23 @@ var (
 )
 
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
-type Org_Federation_CustomMessageArgument struct {
+type FederationService_Org_Federation_CustomMessageArgument struct {
 	Msg string
 }
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_LocalizedMessageArgument is argument for "org.federation.LocalizedMessage" message.
-type Org_Federation_LocalizedMessageArgument struct {
+type FederationService_Org_Federation_LocalizedMessageArgument struct {
 	Value string
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id                  string
 	LocalizedMsg        *LocalizedMessage
 	Post                *post.Post
@@ -178,7 +178,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -190,7 +190,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_CustomMessage resolve "org.federation.CustomMessage" message.
-func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
+func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *FederationService_Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -232,7 +232,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -269,7 +269,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -317,7 +317,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_LocalizedMessage resolve "org.federation.LocalizedMessage" message.
-func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.Context, req *Org_Federation_LocalizedMessageArgument) (*LocalizedMessage, error) {
+func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.Context, req *FederationService_Org_Federation_LocalizedMessageArgument) (*LocalizedMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.LocalizedMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -359,7 +359,7 @@ func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -481,7 +481,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 								return nil
 							},
 							Message: func(ctx context.Context, value *localValueType) (any, error) {
-								args := &Org_Federation_LocalizedMessageArgument{}
+								args := &FederationService_Org_Federation_LocalizedMessageArgument{}
 								// { name: "value", by: "id" }
 								if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 									Value:             value,
@@ -531,7 +531,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 										return nil
 									},
 									Message: func(ctx context.Context, value *localValueType) (any, error) {
-										args := &Org_Federation_CustomMessageArgument{}
+										args := &FederationService_Org_Federation_CustomMessageArgument{}
 										// { name: "msg", by: "id" }
 										if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 											Value:             value,
@@ -724,7 +724,7 @@ func (s *FederationService) logvalue_Org_Federation_CustomMessage(v *CustomMessa
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *Org_Federation_CustomMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *FederationService_Org_Federation_CustomMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -742,7 +742,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -760,7 +760,7 @@ func (s *FederationService) logvalue_Org_Federation_LocalizedMessage(v *Localize
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_LocalizedMessageArgument(v *Org_Federation_LocalizedMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_LocalizedMessageArgument(v *FederationService_Org_Federation_LocalizedMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -779,7 +779,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -26,13 +26,13 @@ var (
 )
 
 // Org_Federation_GetPostsResponseArgument is argument for "org.federation.GetPostsResponse" message.
-type Org_Federation_GetPostsResponseArgument struct {
+type FederationService_Org_Federation_GetPostsResponseArgument struct {
 	Ids   []string
 	Posts *Posts
 }
 
 // Org_Federation_PostsArgument is argument for "org.federation.Posts" message.
-type Org_Federation_PostsArgument struct {
+type FederationService_Org_Federation_PostsArgument struct {
 	Ids     []string
 	Items   []*Posts_PostItem
 	PostIds []string
@@ -42,12 +42,12 @@ type Org_Federation_PostsArgument struct {
 }
 
 // Org_Federation_Posts_PostItemArgument is argument for "org.federation.PostItem" message.
-type Org_Federation_Posts_PostItemArgument struct {
+type FederationService_Org_Federation_Posts_PostItemArgument struct {
 	Id string
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Res    *user.GetUserResponse
 	User   *user.User
 	UserId string
@@ -93,7 +93,7 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_User implements resolver for "org.federation.User".
-	Resolve_Org_Federation_User(context.Context, *Org_Federation_UserArgument) (*User, error)
+	Resolve_Org_Federation_User(context.Context, *FederationService_Org_Federation_UserArgument) (*User, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -111,7 +111,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_User resolve "org.federation.User".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User(context.Context, *Org_Federation_UserArgument) (ret *User, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User(context.Context, *FederationService_Org_Federation_UserArgument) (ret *User, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_User not implemented")
 	return
 }
@@ -212,7 +212,7 @@ func (s *FederationService) GetPosts(ctx context.Context, req *GetPostsRequest) 
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostsResponse(ctx, &Org_Federation_GetPostsResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostsResponse(ctx, &FederationService_Org_Federation_GetPostsResponseArgument{
 		Ids: req.GetIds(),
 	})
 	if err != nil {
@@ -224,7 +224,7 @@ func (s *FederationService) GetPosts(ctx context.Context, req *GetPostsRequest) 
 }
 
 // resolve_Org_Federation_GetPostsResponse resolve "org.federation.GetPostsResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.Context, req *Org_Federation_GetPostsResponseArgument) (*GetPostsResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostsResponseArgument) (*GetPostsResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostsResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -261,7 +261,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostsArgument{}
+			args := &FederationService_Org_Federation_PostsArgument{}
 			// { name: "post_ids", by: "$.ids" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[[]string]{
 				Value:             value,
@@ -309,7 +309,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 }
 
 // resolve_Org_Federation_Posts resolve "org.federation.Posts" message.
-func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, req *Org_Federation_PostsArgument) (*Posts, error) {
+func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, req *FederationService_Org_Federation_PostsArgument) (*Posts, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -543,7 +543,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 			IteratorType:   grpcfed.CELObjectType("org.post.Post"),
 			IteratorSource: func(value *localValueType) []*post.Post { return value.vars.posts },
 			Iterator: func(ctx context.Context, value *grpcfed.MapIteratorValue) (any, error) {
-				args := &Org_Federation_Posts_PostItemArgument{}
+				args := &FederationService_Org_Federation_Posts_PostItemArgument{}
 				// { name: "id", by: "iter.id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -659,7 +659,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 			IteratorType:   grpcfed.CELObjectType("org.post.Post"),
 			IteratorSource: func(value *localValueType) []*post.Post { return value.vars.posts },
 			Iterator: func(ctx context.Context, value *grpcfed.MapIteratorValue) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "iter.user_id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -773,7 +773,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 }
 
 // resolve_Org_Federation_Posts_PostItem resolve "org.federation.Posts.PostItem" message.
-func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Context, req *Org_Federation_Posts_PostItemArgument) (*Posts_PostItem, error) {
+func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Context, req *FederationService_Org_Federation_Posts_PostItemArgument) (*Posts_PostItem, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Posts.PostItem")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -815,7 +815,7 @@ func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Co
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -926,7 +926,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostsResponse(v *GetPosts
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostsResponseArgument(v *Org_Federation_GetPostsResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostsResponseArgument(v *FederationService_Org_Federation_GetPostsResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -948,7 +948,7 @@ func (s *FederationService) logvalue_Org_Federation_Posts(v *Posts) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostsArgument(v *Org_Federation_PostsArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostsArgument(v *FederationService_Org_Federation_PostsArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -966,7 +966,7 @@ func (s *FederationService) logvalue_Org_Federation_Posts_PostItem(v *Posts_Post
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_Posts_PostItemArgument(v *Org_Federation_Posts_PostItemArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_Posts_PostItemArgument(v *FederationService_Org_Federation_Posts_PostItemArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -985,7 +985,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_minimum.go
+++ b/generator/testdata/expected_minimum.go
@@ -23,7 +23,7 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Type PostType
 }
@@ -59,7 +59,7 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_GetPostResponse implements resolver for "org.federation.GetPostResponse".
-	Resolve_Org_Federation_GetPostResponse(context.Context, *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error)
+	Resolve_Org_Federation_GetPostResponse(context.Context, *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -77,7 +77,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_GetPostResponse(context.Context, *Org_Federation_GetPostResponseArgument) (ret *GetPostResponse, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_GetPostResponse(context.Context, *FederationService_Org_Federation_GetPostResponseArgument) (ret *GetPostResponse, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_GetPostResponse not implemented")
 	return
 }
@@ -145,7 +145,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id:   req.GetId(),
 		Type: req.GetType(),
 	})
@@ -158,7 +158,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -187,7 +187,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -25,18 +25,18 @@ var (
 )
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	Uid   *UserID
 	User  *User
 	User2 *User
 }
 
 // Org_Federation_SubArgument is argument for "org.federation.Sub" message.
-type Org_Federation_SubArgument struct {
+type FederationService_Org_Federation_SubArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Res    *user.GetUserResponse
 	User   *user.User
 	UserId string
@@ -44,12 +44,12 @@ type Org_Federation_UserArgument struct {
 }
 
 // Org_Federation_UserIDArgument is argument for "org.federation.UserID" message.
-type Org_Federation_UserIDArgument struct {
+type FederationService_Org_Federation_UserIDArgument struct {
 }
 
 // Org_Federation_User_NameArgument is custom resolver's argument for "name" field of "org.federation.User" message.
-type Org_Federation_User_NameArgument struct {
-	*Org_Federation_UserArgument
+type FederationService_Org_Federation_User_NameArgument struct {
+	*FederationService_Org_Federation_UserArgument
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -89,9 +89,9 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_Sub implements resolver for "org.federation.Sub".
-	Resolve_Org_Federation_Sub(context.Context, *Org_Federation_SubArgument) (*Sub, error)
+	Resolve_Org_Federation_Sub(context.Context, *FederationService_Org_Federation_SubArgument) (*Sub, error)
 	// Resolve_Org_Federation_User_Name implements resolver for "org.federation.User.name".
-	Resolve_Org_Federation_User_Name(context.Context, *Org_Federation_User_NameArgument) (string, error)
+	Resolve_Org_Federation_User_Name(context.Context, *FederationService_Org_Federation_User_NameArgument) (string, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -109,14 +109,14 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_Sub resolve "org.federation.Sub".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Sub(context.Context, *Org_Federation_SubArgument) (ret *Sub, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Sub(context.Context, *FederationService_Org_Federation_SubArgument) (ret *Sub, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_Sub not implemented")
 	return
 }
 
 // Resolve_Org_Federation_User_Name resolve "org.federation.User.name".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Name(context.Context, *Org_Federation_User_NameArgument) (ret string, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Name(context.Context, *FederationService_Org_Federation_User_NameArgument) (ret string, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_User_Name not implemented")
 	return
 }
@@ -202,7 +202,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -212,7 +212,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -260,7 +260,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserIDArgument{}
+				args := &FederationService_Org_Federation_UserIDArgument{}
 				return s.resolve_Org_Federation_UserID(ctx, args)
 			},
 		}); err != nil {
@@ -286,7 +286,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "uid.value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -328,7 +328,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserIDArgument{}
+				args := &FederationService_Org_Federation_UserIDArgument{}
 				return s.resolve_Org_Federation_UserID(ctx, args)
 			},
 		}); err != nil {
@@ -354,7 +354,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "uid.value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -424,7 +424,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 }
 
 // resolve_Org_Federation_Sub resolve "org.federation.Sub" message.
-func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req *Org_Federation_SubArgument) (*Sub, error) {
+func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req *FederationService_Org_Federation_SubArgument) (*Sub, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Sub")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -445,7 +445,7 @@ func (s *FederationService) resolve_Org_Federation_Sub(ctx context.Context, req 
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -492,7 +492,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_SubArgument{}
+				args := &FederationService_Org_Federation_SubArgument{}
 				return s.resolve_Org_Federation_Sub(ctx, args)
 			},
 		}); err != nil {
@@ -589,8 +589,8 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.Name, err = s.resolver.Resolve_Org_Federation_User_Name(ctx, &Org_Federation_User_NameArgument{
-			Org_Federation_UserArgument: req,
+		ret.Name, err = s.resolver.Resolve_Org_Federation_User_Name(ctx, &FederationService_Org_Federation_User_NameArgument{
+			FederationService_Org_Federation_UserArgument: req,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -603,7 +603,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 }
 
 // resolve_Org_Federation_UserID resolve "org.federation.UserID" message.
-func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, req *Org_Federation_UserIDArgument) (*UserID, error) {
+func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, req *FederationService_Org_Federation_UserIDArgument) (*UserID, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserID")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -639,7 +639,7 @@ func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, r
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_SubArgument{}
+			args := &FederationService_Org_Federation_SubArgument{}
 			return s.resolve_Org_Federation_Sub(ctx, args)
 		},
 	}); err != nil {
@@ -680,7 +680,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -694,7 +694,7 @@ func (s *FederationService) logvalue_Org_Federation_Sub(v *Sub) slog.Value {
 	return slog.GroupValue()
 }
 
-func (s *FederationService) logvalue_Org_Federation_SubArgument(v *Org_Federation_SubArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_SubArgument(v *FederationService_Org_Federation_SubArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -711,7 +711,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -729,7 +729,7 @@ func (s *FederationService) logvalue_Org_Federation_UserID(v *UserID) slog.Value
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserIDArgument(v *Org_Federation_UserIDArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserIDArgument(v *FederationService_Org_Federation_UserIDArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -25,21 +25,21 @@ var (
 )
 
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type Org_Federation_GetResponseArgument struct {
+type FederationService_Org_Federation_GetResponseArgument struct {
 	Sel *UserSelection
 }
 
 // Org_Federation_MArgument is argument for "org.federation.M" message.
-type Org_Federation_MArgument struct {
+type FederationService_Org_Federation_MArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	UserId string
 }
 
 // Org_Federation_UserSelectionArgument is argument for "org.federation.UserSelection" message.
-type Org_Federation_UserSelectionArgument struct {
+type FederationService_Org_Federation_UserSelectionArgument struct {
 	M     *M
 	Ua    *User
 	Ub    *User
@@ -181,7 +181,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetResponse(ctx, &Org_Federation_GetResponseArgument{})
+	res, err := s.resolve_Org_Federation_GetResponse(ctx, &FederationService_Org_Federation_GetResponseArgument{})
 	if err != nil {
 		grpcfed.RecordErrorToSpan(ctx, err)
 		grpcfed.OutputErrorLog(ctx, err)
@@ -191,7 +191,7 @@ func (s *FederationService) Get(ctx context.Context, req *GetRequest) (res *GetR
 }
 
 // resolve_Org_Federation_GetResponse resolve "org.federation.GetResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *Org_Federation_GetResponseArgument) (*GetResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Context, req *FederationService_Org_Federation_GetResponseArgument) (*GetResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -228,7 +228,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_UserSelectionArgument{}
+			args := &FederationService_Org_Federation_UserSelectionArgument{}
 			// { name: "value", by: "'foo'" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -276,7 +276,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 }
 
 // resolve_Org_Federation_M resolve "org.federation.M" message.
-func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *Org_Federation_MArgument) (*M, error) {
+func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *FederationService_Org_Federation_MArgument) (*M, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.M")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -318,7 +318,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -453,7 +453,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 }
 
 // resolve_Org_Federation_UserSelection resolve "org.federation.UserSelection" message.
-func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Context, req *Org_Federation_UserSelectionArgument) (*UserSelection, error) {
+func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Context, req *FederationService_Org_Federation_UserSelectionArgument) (*UserSelection, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.UserSelection")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -492,7 +492,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_MArgument{}
+			args := &FederationService_Org_Federation_MArgument{}
 			return s.resolve_Org_Federation_M(ctx, args)
 		},
 	}); err != nil {
@@ -553,7 +553,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "'a'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -606,7 +606,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "'b'" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -659,7 +659,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { name: "user_id", by: "$.value" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -707,7 +707,7 @@ func (s *FederationService) logvalue_Org_Federation_GetResponse(v *GetResponse) 
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *Org_Federation_GetResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetResponseArgument(v *FederationService_Org_Federation_GetResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -723,7 +723,7 @@ func (s *FederationService) logvalue_Org_Federation_M(v *M) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_MArgument(v *Org_Federation_MArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_MArgument(v *FederationService_Org_Federation_MArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -739,7 +739,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -759,7 +759,7 @@ func (s *FederationService) logvalue_Org_Federation_UserSelection(v *UserSelecti
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserSelectionArgument(v *Org_Federation_UserSelectionArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserSelectionArgument(v *FederationService_Org_Federation_UserSelectionArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_ref_env.go
+++ b/generator/testdata/expected_ref_env.go
@@ -22,10 +22,6 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_EnvArgument is argument for "org.federation.Env" message.
-type Org_Federation_EnvArgument struct {
-}
-
 // RefEnvServiceConfig configuration required to initialize the service that use GRPC Federation.
 type RefEnvServiceConfig struct {
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -25,19 +25,19 @@ var (
 )
 
 // Org_Federation_GetPostResponse1Argument is argument for "org.federation.GetPostResponse1" message.
-type Org_Federation_GetPostResponse1Argument struct {
+type FederationService_Org_Federation_GetPostResponse1Argument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_GetPostResponse2Argument is argument for "org.federation.GetPostResponse2" message.
-type Org_Federation_GetPostResponse2Argument struct {
+type FederationService_Org_Federation_GetPostResponse2Argument struct {
 	Id   string
 	Post *Post
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id  string
 	Res *post.GetPostResponse
 }
@@ -169,7 +169,7 @@ func (s *FederationService) GetPost1(ctx context.Context, req *GetPostRequest) (
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse1(ctx, &Org_Federation_GetPostResponse1Argument{
+	res, err := s.resolve_Org_Federation_GetPostResponse1(ctx, &FederationService_Org_Federation_GetPostResponse1Argument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -192,7 +192,7 @@ func (s *FederationService) GetPost2(ctx context.Context, req *GetPostRequest) (
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse2(ctx, &Org_Federation_GetPostResponse2Argument{
+	res, err := s.resolve_Org_Federation_GetPostResponse2(ctx, &FederationService_Org_Federation_GetPostResponse2Argument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -204,7 +204,7 @@ func (s *FederationService) GetPost2(ctx context.Context, req *GetPostRequest) (
 }
 
 // resolve_Org_Federation_GetPostResponse1 resolve "org.federation.GetPostResponse1" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.Context, req *Org_Federation_GetPostResponse1Argument) (*GetPostResponse1, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.Context, req *FederationService_Org_Federation_GetPostResponse1Argument) (*GetPostResponse1, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse1")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -241,7 +241,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -289,7 +289,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.
 }
 
 // resolve_Org_Federation_GetPostResponse2 resolve "org.federation.GetPostResponse2" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.Context, req *Org_Federation_GetPostResponse2Argument) (*GetPostResponse2, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.Context, req *FederationService_Org_Federation_GetPostResponse2Argument) (*GetPostResponse2, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse2")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -326,7 +326,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.
 			return nil
 		},
 		Message: func(ctx context.Context, value *localValueType) (any, error) {
-			args := &Org_Federation_PostArgument{}
+			args := &FederationService_Org_Federation_PostArgument{}
 			// { name: "id", by: "$.id" }
 			if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 				Value:             value,
@@ -374,7 +374,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -470,7 +470,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse1(v *GetPostR
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponse1Argument(v *Org_Federation_GetPostResponse1Argument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponse1Argument(v *FederationService_Org_Federation_GetPostResponse1Argument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -488,7 +488,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse2(v *GetPostR
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponse2Argument(v *Org_Federation_GetPostResponse2Argument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponse2Argument(v *FederationService_Org_Federation_GetPostResponse2Argument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -506,7 +506,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -27,25 +27,21 @@ var (
 )
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id       string
 	MapValue map[int64]string
 	Post     *Post
 	Uuid     *grpcfedcel.UUID
 }
 
-// Org_Federation_ItemArgument is argument for "org.federation.Item" message.
-type Org_Federation_ItemArgument struct {
-}
-
 // Org_Federation_MArgument is argument for "org.federation.M" message.
-type Org_Federation_MArgument struct {
+type FederationService_Org_Federation_MArgument struct {
 	X uint64
 	Y user.Item_ItemType
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 	Id   string
 	M    *M
 	Post *post.Post
@@ -54,7 +50,7 @@ type Org_Federation_PostArgument struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
-type Org_Federation_UserArgument struct {
+type FederationService_Org_Federation_UserArgument struct {
 	Content string
 	Id      string
 	Res     *user.GetUserResponse
@@ -65,20 +61,12 @@ type Org_Federation_UserArgument struct {
 }
 
 // Org_Federation_User_AgeArgument is custom resolver's argument for "age" field of "org.federation.User" message.
-type Org_Federation_User_AgeArgument struct {
-	*Org_Federation_UserArgument
-}
-
-// Org_Federation_User_AttrAArgument is argument for "org.federation.AttrA" message.
-type Org_Federation_User_AttrAArgument struct {
-}
-
-// Org_Federation_User_AttrBArgument is argument for "org.federation.AttrB" message.
-type Org_Federation_User_AttrBArgument struct {
+type FederationService_Org_Federation_User_AgeArgument struct {
+	*FederationService_Org_Federation_UserArgument
 }
 
 // Org_Federation_ZArgument is argument for "org.federation.Z" message.
-type Org_Federation_ZArgument struct {
+type FederationService_Org_Federation_ZArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -121,9 +109,9 @@ type FederationServiceDependentClientSet struct {
 // FederationServiceResolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 type FederationServiceResolver interface {
 	// Resolve_Org_Federation_User_Age implements resolver for "org.federation.User.age".
-	Resolve_Org_Federation_User_Age(context.Context, *Org_Federation_User_AgeArgument) (uint64, error)
+	Resolve_Org_Federation_User_Age(context.Context, *FederationService_Org_Federation_User_AgeArgument) (uint64, error)
 	// Resolve_Org_Federation_Z implements resolver for "org.federation.Z".
-	Resolve_Org_Federation_Z(context.Context, *Org_Federation_ZArgument) (*Z, error)
+	Resolve_Org_Federation_Z(context.Context, *FederationService_Org_Federation_ZArgument) (*Z, error)
 }
 
 // FederationServiceCELPluginWasmConfig type alias for grpcfedcel.WasmConfig.
@@ -141,14 +129,14 @@ type FederationServiceUnimplementedResolver struct{}
 
 // Resolve_Org_Federation_User_Age resolve "org.federation.User.age".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Age(context.Context, *Org_Federation_User_AgeArgument) (ret uint64, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_User_Age(context.Context, *FederationService_Org_Federation_User_AgeArgument) (ret uint64, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_User_Age not implemented")
 	return
 }
 
 // Resolve_Org_Federation_Z resolve "org.federation.Z".
 // This method always returns Unimplemented error.
-func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Z(context.Context, *Org_Federation_ZArgument) (ret *Z, e error) {
+func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_Z(context.Context, *FederationService_Org_Federation_ZArgument) (ret *Z, e error) {
 	e = grpcfed.GRPCErrorf(grpcfed.UnimplementedCode, "method Resolve_Org_Federation_Z not implemented")
 	return
 }
@@ -257,7 +245,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 		}
 	}()
 	res, err := grpcfed.WithTimeout[GetPostResponse](ctx, "org.federation.FederationService/GetPost", 60000000000 /* 1m0s */, func(ctx context.Context) (*GetPostResponse, error) {
-		return s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+		return s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 			Id: req.GetId(),
 		})
 	})
@@ -270,7 +258,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -344,7 +332,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				// { name: "id", by: "$.id" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:             value,
@@ -504,7 +492,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_M resolve "org.federation.M" message.
-func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *Org_Federation_MArgument) (*M, error) {
+func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *FederationService_Org_Federation_MArgument) (*M, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.M")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -560,7 +548,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *O
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -616,7 +604,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_MArgument{}
+				args := &FederationService_Org_Federation_MArgument{}
 				// { name: "x", by: "10" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[int64]{
 					Value:             value,
@@ -759,7 +747,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_UserArgument{}
+				args := &FederationService_Org_Federation_UserArgument{}
 				// { inline: "post" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*post.Post]{
 					Value:             value,
@@ -804,7 +792,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_ZArgument{}
+				args := &FederationService_Org_Federation_ZArgument{}
 				return s.resolve_Org_Federation_Z(ctx, args)
 			},
 		}); err != nil {
@@ -853,7 +841,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 }
 
 // resolve_Org_Federation_User resolve "org.federation.User" message.
-func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *Org_Federation_UserArgument) (*User, error) {
+func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req *FederationService_Org_Federation_UserArgument) (*User, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.User")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -904,7 +892,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_MArgument{}
+				args := &FederationService_Org_Federation_MArgument{}
 				// { name: "x", by: "uint(2)" }
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[uint64]{
 					Value:             value,
@@ -1056,8 +1044,8 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		// (grpc.federation.field).custom_resolver = true
 		ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx)) // create a new reference to logger.
 		var err error
-		ret.Age, err = s.resolver.Resolve_Org_Federation_User_Age(ctx, &Org_Federation_User_AgeArgument{
-			Org_Federation_UserArgument: req,
+		ret.Age, err = s.resolver.Resolve_Org_Federation_User_Age(ctx, &FederationService_Org_Federation_User_AgeArgument{
+			FederationService_Org_Federation_UserArgument: req,
 		})
 		if err != nil {
 			grpcfed.RecordErrorToSpan(ctx, err)
@@ -1104,7 +1092,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 }
 
 // resolve_Org_Federation_Z resolve "org.federation.Z" message.
-func (s *FederationService) resolve_Org_Federation_Z(ctx context.Context, req *Org_Federation_ZArgument) (*Z, error) {
+func (s *FederationService) resolve_Org_Federation_Z(ctx context.Context, req *FederationService_Org_Federation_ZArgument) (*Z, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Z")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -1301,7 +1289,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1354,7 +1342,7 @@ func (s *FederationService) logvalue_Org_Federation_M(v *M) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_MArgument(v *Org_Federation_MArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_MArgument(v *FederationService_Org_Federation_MArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1378,7 +1366,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1405,7 +1393,7 @@ func (s *FederationService) logvalue_Org_Federation_User(v *User) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_UserArgument(v *Org_Federation_UserArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_UserArgument(v *FederationService_Org_Federation_UserArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -1465,7 +1453,7 @@ func (s *FederationService) logvalue_Org_Federation_Z(v *Z) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_ZArgument(v *Org_Federation_ZArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_ZArgument(v *FederationService_Org_Federation_ZArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/generator/testdata/expected_validation.go
+++ b/generator/testdata/expected_validation.go
@@ -23,12 +23,12 @@ var (
 )
 
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
-type Org_Federation_CustomMessageArgument struct {
+type FederationService_Org_Federation_CustomMessageArgument struct {
 	Message string
 }
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type Org_Federation_GetPostResponseArgument struct {
+type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id                  string
 	Post                *Post
 	XDef2ErrDetail0Msg0 *CustomMessage
@@ -36,7 +36,7 @@ type Org_Federation_GetPostResponseArgument struct {
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type Org_Federation_PostArgument struct {
+type FederationService_Org_Federation_PostArgument struct {
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -141,7 +141,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 			grpcfed.OutputErrorLog(ctx, e)
 		}
 	}()
-	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &Org_Federation_GetPostResponseArgument{
+	res, err := s.resolve_Org_Federation_GetPostResponse(ctx, &FederationService_Org_Federation_GetPostResponseArgument{
 		Id: req.GetId(),
 	})
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *FederationService) GetPost(ctx context.Context, req *GetPostRequest) (r
 }
 
 // resolve_Org_Federation_CustomMessage resolve "org.federation.CustomMessage" message.
-func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
+func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Context, req *FederationService_Org_Federation_CustomMessageArgument) (*CustomMessage, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.CustomMessage")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -195,7 +195,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 }
 
 // resolve_Org_Federation_GetPostResponse resolve "org.federation.GetPostResponse" message.
-func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
+func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.Context, req *FederationService_Org_Federation_GetPostResponseArgument) (*GetPostResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.GetPostResponse")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -245,7 +245,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				return s.resolve_Org_Federation_Post(ctx, args)
 			},
 		}); err != nil {
@@ -326,7 +326,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 				return nil
 			},
 			Message: func(ctx context.Context, value *localValueType) (any, error) {
-				args := &Org_Federation_PostArgument{}
+				args := &FederationService_Org_Federation_PostArgument{}
 				return s.resolve_Org_Federation_Post(ctx, args)
 			},
 		}); err != nil {
@@ -418,7 +418,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 												return nil
 											},
 											Message: func(ctx context.Context, value *localValueType) (any, error) {
-												args := &Org_Federation_CustomMessageArgument{}
+												args := &FederationService_Org_Federation_CustomMessageArgument{}
 												// { name: "message", by: "'message1'" }
 												if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 													Value:             value,
@@ -461,7 +461,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 												return nil
 											},
 											Message: func(ctx context.Context, value *localValueType) (any, error) {
-												args := &Org_Federation_CustomMessageArgument{}
+												args := &FederationService_Org_Federation_CustomMessageArgument{}
 												// { name: "message", by: "'message2'" }
 												if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 													Value:             value,
@@ -603,7 +603,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 }
 
 // resolve_Org_Federation_Post resolve "org.federation.Post" message.
-func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *Org_Federation_PostArgument) (*Post, error) {
+func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req *FederationService_Org_Federation_PostArgument) (*Post, error) {
 	ctx, span := s.tracer.Start(ctx, "org.federation.Post")
 	defer span.End()
 	ctx = grpcfed.WithLogger(ctx, grpcfed.Logger(ctx), grpcfed.LogAttrs(ctx)...)
@@ -681,7 +681,7 @@ func (s *FederationService) logvalue_Org_Federation_CustomMessage(v *CustomMessa
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *Org_Federation_CustomMessageArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_CustomMessageArgument(v *FederationService_Org_Federation_CustomMessageArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -699,7 +699,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *Org_Federation_GetPostResponseArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_GetPostResponseArgument(v *FederationService_Org_Federation_GetPostResponseArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}
@@ -719,7 +719,7 @@ func (s *FederationService) logvalue_Org_Federation_Post(v *Post) slog.Value {
 	)
 }
 
-func (s *FederationService) logvalue_Org_Federation_PostArgument(v *Org_Federation_PostArgument) slog.Value {
+func (s *FederationService) logvalue_Org_Federation_PostArgument(v *FederationService_Org_Federation_PostArgument) slog.Value {
 	if v == nil {
 		return slog.GroupValue()
 	}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2815,6 +2815,7 @@ func (r *Resolver) resolveMessageArgument(ctx *context, files []*File) {
 			// A non-response message may also become a root message.
 			// In such a case, the message argument field does not exist.
 			// However, since it is necessary to resolve the CEL reference, needs to call recursive message argument resolver.
+			ctx := newContext().withFile(ctx.file()) // ignore if exists error.
 			_ = r.resolveMessageArgumentRecursive(ctx, root, svcMsgSet)
 			continue
 		}

--- a/testdata/simple_aggregation.proto
+++ b/testdata/simple_aggregation.proto
@@ -169,3 +169,11 @@ message M {
   string foo = 1 [(grpc.federation.field).by = "'foo'"];
   int64 bar = 2 [(grpc.federation.field).by = "1"];
 }
+
+message N {
+  option (grpc.federation.message) = {
+    def { by: "$.foo" }
+  };
+
+  string foo = 1 [(grpc.federation.field).by = "$.foo"];
+}


### PR DESCRIPTION
- Generate the message arguments used in the Service with the service prefix attached.
- Resolve unreferenced messages, but ignore error