### PR TITLE
Embed unimplemented server by value instead of pointer

### DIFF
--- a/_examples/01_minimum/federation/federation_grpc_federation.pb.go
+++ b/_examples/01_minimum/federation/federation_grpc_federation.pb.go
@@ -83,7 +83,7 @@ func (FederationServiceUnimplementedResolver) Resolve_Federation_GetPostResponse
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -161,7 +161,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -203,7 +203,7 @@ const (
 
 // FederationV2DevService represents Federation Service.
 type FederationV2DevService struct {
-	*UnimplementedFederationV2DevServiceServer
+	UnimplementedFederationV2DevServiceServer
 	cfg           FederationV2DevServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -91,7 +91,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/05_async/federation/federation_grpc_federation.pb.go
+++ b/_examples/05_async/federation/federation_grpc_federation.pb.go
@@ -138,7 +138,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -120,7 +120,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -97,7 +97,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -89,7 +89,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -127,7 +127,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -107,7 +107,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
@@ -119,7 +119,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler
@@ -1025,7 +1025,7 @@ type PrivateServiceUnimplementedResolver struct{}
 
 // PrivateService represents Federation Service.
 type PrivateService struct {
-	*UnimplementedPrivateServiceServer
+	UnimplementedPrivateServiceServer
 	cfg           PrivateServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler
@@ -1910,7 +1910,7 @@ type DebugServiceUnimplementedResolver struct{}
 
 // DebugService represents Federation Service.
 type DebugService struct {
-	*UnimplementedDebugServiceServer
+	UnimplementedDebugServiceServer
 	cfg           DebugServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/11_multi_service/federation/other_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/other_grpc_federation.pb.go
@@ -92,7 +92,7 @@ func (OtherServiceUnimplementedResolver) Resolve_Federation_GetResponse_Post(con
 
 // OtherService represents Federation Service.
 type OtherService struct {
-	*UnimplementedOtherServiceServer
+	UnimplementedOtherServiceServer
 	cfg           OtherServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/12_validation/federation/federation_grpc_federation.pb.go
+++ b/_examples/12_validation/federation/federation_grpc_federation.pb.go
@@ -101,7 +101,7 @@ func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_CustomHandl
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -111,7 +111,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -99,7 +99,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
@@ -81,7 +81,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
@@ -83,7 +83,7 @@ func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_GetResponse
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -103,7 +103,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/18_load/federation/federation_grpc_federation.pb.go
+++ b/_examples/18_load/federation/federation_grpc_federation.pb.go
@@ -77,7 +77,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -88,7 +88,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/demo/swapi/swapi/swapi_grpc_federation.pb.go
+++ b/demo/swapi/swapi/swapi_grpc_federation.pb.go
@@ -266,7 +266,7 @@ const (
 
 // SWAPI represents Federation Service.
 type SWAPI struct {
-	*UnimplementedSWAPIServer
+	UnimplementedSWAPIServer
 	cfg           SWAPIConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/templates/server.go.tmpl
+++ b/generator/templates/server.go.tmpl
@@ -169,7 +169,7 @@ const (
 
 // {{ $serviceName }} represents Federation Service.
 type {{ $serviceName }} struct {
-	*Unimplemented{{ $serviceName }}Server
+	Unimplemented{{ $serviceName }}Server
 	cfg {{ $serviceName }}Config
 	logger *slog.Logger
 	errorHandler grpcfed.ErrorHandler

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -111,7 +111,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_async.go
+++ b/generator/testdata/expected_async.go
@@ -138,7 +138,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -97,7 +97,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -99,7 +99,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -101,7 +101,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -148,7 +148,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_env.go
+++ b/generator/testdata/expected_env.go
@@ -93,7 +93,7 @@ type InlineEnvServiceUnimplementedResolver struct{}
 
 // InlineEnvService represents Federation Service.
 type InlineEnvService struct {
-	*UnimplementedInlineEnvServiceServer
+	UnimplementedInlineEnvServiceServer
 	cfg           InlineEnvServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler
@@ -212,7 +212,7 @@ type RefEnvServiceUnimplementedResolver struct{}
 
 // RefEnvService represents Federation Service.
 type RefEnvService struct {
-	*UnimplementedRefEnvServiceServer
+	UnimplementedRefEnvServiceServer
 	cfg           RefEnvServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -103,7 +103,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_inline_env.go
+++ b/generator/testdata/expected_inline_env.go
@@ -89,7 +89,7 @@ type InlineEnvServiceUnimplementedResolver struct{}
 
 // InlineEnvService represents Federation Service.
 type InlineEnvService struct {
-	*UnimplementedInlineEnvServiceServer
+	UnimplementedInlineEnvServiceServer
 	cfg           InlineEnvServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -123,7 +123,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_minimum.go
+++ b/generator/testdata/expected_minimum.go
@@ -84,7 +84,7 @@ func (FederationServiceUnimplementedResolver) Resolve_Org_Federation_GetPostResp
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -127,7 +127,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -101,7 +101,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_ref_env.go
+++ b/generator/testdata/expected_ref_env.go
@@ -93,7 +93,7 @@ type RefEnvServiceUnimplementedResolver struct{}
 
 // RefEnvService represents Federation Service.
 type RefEnvService struct {
-	*UnimplementedRefEnvServiceServer
+	UnimplementedRefEnvServiceServer
 	cfg           RefEnvServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -96,7 +96,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -160,7 +160,7 @@ const (
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler

--- a/generator/testdata/expected_validation.go
+++ b/generator/testdata/expected_validation.go
@@ -83,7 +83,7 @@ type FederationServiceUnimplementedResolver struct{}
 
 // FederationService represents Federation Service.
 type FederationService struct {
-	*UnimplementedFederationServiceServer
+	UnimplementedFederationServiceServer
 	cfg           FederationServiceConfig
 	logger        *slog.Logger
 	errorHandler  grpcfed.ErrorHandler


### PR DESCRIPTION
Since https://github.com/grpc/grpc-go/pull/7438 was merged, our unit tests started failing since we embeded the unimplemented servers by pointer. To fix the problem, use value instead.