### PR TITLE
Remove unnecessary RecordErrorToSpan process

### DIFF
--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -1578,7 +1578,6 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			})
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}
@@ -1775,7 +1774,6 @@ func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Fe
 			})
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -706,7 +706,6 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 				ret, err := s.client.Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationV2DevService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -931,7 +930,6 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Conte
 			ret, err := s.client.User_UserServiceClient.GetUser(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationV2DevService_DependentMethod_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -305,7 +305,6 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			ret, err := s.client.Post_PostServiceClient.GetPost(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -379,7 +379,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Org_Post_V2_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_V2_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -550,7 +549,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -314,7 +314,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -658,7 +658,6 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			ret, err := s.client.Content_ContentServiceClient.GetContent(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Content_ContentService_GetContent, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -543,7 +543,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				ret, err := s.client.User_UserServiceClient.GetUser(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_User_UserService_GetUser, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -527,7 +527,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			ret, err := s.client.User_UserServiceClient.GetUser(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -355,7 +355,6 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 				ret, err := s.client.Post_PostServiceClient.GetPosts(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPosts, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -462,7 +461,6 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 				ret, err := s.client.Post_PostServiceClient.GetPosts(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPosts, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -580,7 +578,6 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 				ret, err := s.client.Post_PostServiceClient.GetPosts(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPosts, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -833,7 +830,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			ret, err := s.client.User_UserServiceClient.GetUser(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -324,7 +324,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -421,7 +420,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -687,17 +687,14 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 					grpcfed.Logger(ctx).ErrorContext(ctx, "failed to handle error", slog.String("error", handleErr.Error()))
 					// If it fails during error handling, return the original error.
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				} else if stat != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, stat.status.Err()); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, stat.logLevel, grpcfed.LogAttrs(ctx))
 					}
 				} else {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -294,7 +294,6 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			})
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Post_PostService_GetPost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/templates/error_handler.go.tmpl
+++ b/generator/templates/error_handler.go.tmpl
@@ -154,23 +154,19 @@ if handleErr != nil {
 	grpcfed.Logger(ctx).ErrorContext(ctx, "failed to handle error", slog.String("error", handleErr.Error()))
 	// If it fails during error handling, return the original error.
 	if err := s.errorHandler(ctx, {{ $def.ServiceName }}_DependentMethod_{{ $def.DependentMethodName }}, err); err != nil {
-		grpcfed.RecordErrorToSpan(ctx, err)
 		return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 	}
 } else if stat != nil {
 	if err := s.errorHandler(ctx, {{ $def.ServiceName }}_DependentMethod_{{ $def.DependentMethodName }}, stat.status.Err()); err != nil {
-		grpcfed.RecordErrorToSpan(ctx, err)
 		return nil, grpcfed.NewErrorWithLogAttrs(err, stat.logLevel, grpcfed.LogAttrs(ctx))
 	}
 } else {
 	if err := s.errorHandler(ctx, {{ $def.ServiceName }}_DependentMethod_{{ $def.DependentMethodName }}, err); err != nil {
-		grpcfed.RecordErrorToSpan(ctx, err)
 		return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 	}
 }
 {{- else }}
 if err := s.errorHandler(ctx, {{ $def.ServiceName }}_DependentMethod_{{ $def.DependentMethodName }}, err); err != nil {
-	grpcfed.RecordErrorToSpan(ctx, err)
 	return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 }
 {{- end }}

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -399,7 +399,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -314,7 +314,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -325,7 +325,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -422,7 +421,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -414,7 +414,6 @@ func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx contex
 			ret, err := s.client.Org_Post_PostServiceClient.CreatePost(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_CreatePost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -382,7 +382,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}
@@ -540,7 +539,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			ret, err := s.client.Org_User_UserServiceClient.GetUser(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -663,17 +663,14 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 					grpcfed.Logger(ctx).ErrorContext(ctx, "failed to handle error", slog.String("error", handleErr.Error()))
 					// If it fails during error handling, return the original error.
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				} else if stat != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, stat.status.Err()); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, stat.logLevel, grpcfed.LogAttrs(ctx))
 					}
 				} else {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -374,7 +374,6 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 				ret, err := s.client.Org_Post_PostServiceClient.GetPosts(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPosts, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -481,7 +480,6 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 				ret, err := s.client.Org_Post_PostServiceClient.GetPosts(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPosts, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -599,7 +597,6 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 				ret, err := s.client.Org_Post_PostServiceClient.GetPosts(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPosts, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -852,7 +849,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			ret, err := s.client.Org_User_UserServiceClient.GetUser(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -545,7 +545,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				ret, err := s.client.Org_User_UserServiceClient.GetUser(ctx, args)
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_User_UserService_GetUser, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -404,7 +404,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			ret, err := s.client.Org_User_UserServiceClient.GetUser(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_User_UserService_GetUser, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -417,7 +417,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			ret, err := s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
 			if err != nil {
 				if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-					grpcfed.RecordErrorToSpan(ctx, err)
 					return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 				}
 			}

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -678,7 +678,6 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				})
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_Post_PostService_GetPost, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}
@@ -969,7 +968,6 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				})
 				if err != nil {
 					if err := s.errorHandler(ctx, FederationService_DependentMethod_Org_User_UserService_GetUser, err); err != nil {
-						grpcfed.RecordErrorToSpan(ctx, err)
 						return nil, grpcfed.NewErrorWithLogAttrs(err, slog.LevelError, grpcfed.LogAttrs(ctx))
 					}
 				}


### PR DESCRIPTION
FYI: Call `RecordErrorToSpan` here ( https://github.com/mercari/grpc-federation/blob/main/generator/templates/eval.go.tmpl#L129 )