### PR TITLE
Fix Candidates method file match

### DIFF
--- a/resolver/candidates.go
+++ b/resolver/candidates.go
@@ -71,7 +71,7 @@ func (c ValueCandidates) Filter(typ *Type) ValueCandidates {
 
 func (r *Resolver) Candidates(loc *source.Location) []string {
 	for _, file := range r.files {
-		if strings.HasSuffix(file.GetName(), loc.FileName) {
+		if strings.HasSuffix(loc.FileName, file.GetName()) {
 			protoPkgName := file.GetPackage()
 			switch {
 			case loc.Message != nil:

--- a/source/file.go
+++ b/source/file.go
@@ -200,7 +200,7 @@ func (f *File) buildLocation(ctx *findContext) *Location {
 
 // FindLocationByPos returns the corresponding location information from the position in the source code.
 func (f *File) FindLocationByPos(pos Position) *Location {
-	ctx := &findContext{fileName: f.fileNode.Name()}
+	ctx := &findContext{fileName: f.Path()}
 	for _, decl := range f.fileNode.Decls {
 		ctx := ctx.child()
 		switch n := decl.(type) {

--- a/source/file_test.go
+++ b/source/file_test.go
@@ -36,7 +36,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  47,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Service: &source.Service{
 					Name: "FederationService",
 					Method: &source.Method{
@@ -54,7 +54,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  16,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Service: &source.Service{
 					Name: "FederationService",
 					Method: &source.Method{
@@ -72,7 +72,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  20,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "Post",
 					Option: &source.MessageOption{
@@ -92,7 +92,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  29,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "Post",
 					Option: &source.MessageOption{
@@ -114,7 +114,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  39,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "Post",
 					Option: &source.MessageOption{
@@ -136,7 +136,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  47,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "GetPostResponse",
 					Field: &source.Field{
@@ -154,7 +154,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  15,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "GetPostResponse",
 					Option: &source.MessageOption{
@@ -176,7 +176,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  24,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "GetPostResponse",
 					Option: &source.MessageOption{
@@ -198,7 +198,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  34,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "GetPostResponse",
 					Option: &source.MessageOption{
@@ -220,7 +220,7 @@ func TestFile_FindLocationByPos(t *testing.T) {
 				Col:  26,
 			},
 			expected: &source.Location{
-				FileName: "service.proto",
+				FileName: "testdata/service.proto",
 				Message: &source.Message{
 					Name: "Post",
 					Option: &source.MessageOption{


### PR DESCRIPTION
`strings.HasSuffix(file.GetName(), loc.FileName)` could match the wrong file if there are multiple files with the same name. Instead, set the fileName field to the full file path and use that.