### PR TITLE
Fix private package name

### DIFF
--- a/_examples/01_minimum/federation/federation_grpc_federation.pb.go
+++ b/_examples/01_minimum/federation/federation_grpc_federation.pb.go
@@ -110,7 +110,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}

--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -204,18 +204,18 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.AArgument":   {},
-		"grpc.federation.private.A_BArgument": {},
-		"grpc.federation.private.A_B_CArgument": {
+		"grpc.federation.private.federation.AArgument":   {},
+		"grpc.federation.private.federation.A_BArgument": {},
+		"grpc.federation.private.federation.A_B_CArgument": {
 			"type": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Type"),
 		},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.federation.UserArgument": {
 			"id":      grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"title":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Title"),
 			"content": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Content"),
@@ -292,7 +292,7 @@ func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Feder
 			B *A_B
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.AArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.AArgument", req)}
 	/*
 		def {
 		  name: "b"
@@ -366,7 +366,7 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 			XDef3 bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.A_BArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.A_BArgument", req)}
 	/*
 		def {
 		  name: "foo"
@@ -606,7 +606,7 @@ func (s *FederationService) resolve_Federation_A_B_C(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.A_B_CArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.A_B_CArgument", req)}
 
 	// create a message value to be returned.
 	ret := &A_B_C{}
@@ -665,7 +665,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			XDef16       bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -1983,7 +1983,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			User *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -2160,7 +2160,7 @@ func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Fe
 			User *user.User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -266,21 +266,21 @@ func NewFederationV2DevService(cfg FederationV2DevServiceConfig) (*FederationV2D
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.ForNamelessArgument": {
+		"grpc.federation.private.federation.v2dev.ForNamelessArgument": {
 			"bar": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Bar"),
 		},
-		"grpc.federation.private.GetPostV2devResponseArgument": {
+		"grpc.federation.private.federation.v2dev.GetPostV2devResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostV2devArgument": {
+		"grpc.federation.private.federation.v2dev.PostV2devArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.RefArgument":      {},
-		"grpc.federation.private.TypedNilArgument": {},
-		"grpc.federation.private.UnusedArgument": {
+		"grpc.federation.private.federation.v2dev.RefArgument":      {},
+		"grpc.federation.private.federation.v2dev.TypedNilArgument": {},
+		"grpc.federation.private.federation.v2dev.UnusedArgument": {
 			"foo": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Foo"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.federation.v2dev.UserArgument": {
 			"id":      grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"title":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Title"),
 			"content": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Content"),
@@ -390,7 +390,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(c
 			R    *Ref
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostV2devResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.v2dev.GetPostV2devResponseArgument", req)}
 	value.AddEnv(s.env)
 	/*
 		def {
@@ -601,7 +601,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 			XDef7     bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostV2devArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.v2dev.PostV2devArgument", req)}
 	value.AddEnv(s.env)
 	/*
 		def {
@@ -993,7 +993,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_Ref(ctx context.Contex
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.RefArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.v2dev.RefArgument", req)}
 	value.AddEnv(s.env)
 
 	// create a message value to be returned.
@@ -1074,7 +1074,7 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Conte
 			U   *user.User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.v2dev.UserArgument", req)}
 	value.AddEnv(s.env)
 	/*
 		def {

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -130,13 +130,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UpdatePostResponseArgument": {
+		"grpc.federation.private.federation.UpdatePostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -236,7 +236,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -321,7 +321,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			Res  *post.GetPostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -423,7 +423,7 @@ func (s *FederationService) resolve_Federation_UpdatePostResponse(ctx context.Co
 			XDef0 *post.UpdatePostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UpdatePostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.UpdatePostResponseArgument", req)}
 	/*
 		def {
 		  name: "_def0"

--- a/_examples/05_async/federation/federation_grpc_federation.pb.go
+++ b/_examples/05_async/federation/federation_grpc_federation.pb.go
@@ -161,33 +161,33 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.AAArgument": {},
-		"grpc.federation.private.AArgument":  {},
-		"grpc.federation.private.ABArgument": {},
-		"grpc.federation.private.BArgument":  {},
-		"grpc.federation.private.CArgument": {
+		"grpc.federation.private.org.federation.AAArgument": {},
+		"grpc.federation.private.org.federation.AArgument":  {},
+		"grpc.federation.private.org.federation.ABArgument": {},
+		"grpc.federation.private.org.federation.BArgument":  {},
+		"grpc.federation.private.org.federation.CArgument": {
 			"a": grpcfed.NewCELFieldType(grpcfed.CELStringType, "A"),
 		},
-		"grpc.federation.private.DArgument": {
+		"grpc.federation.private.org.federation.DArgument": {
 			"b": grpcfed.NewCELFieldType(grpcfed.CELStringType, "B"),
 		},
-		"grpc.federation.private.EArgument": {
+		"grpc.federation.private.org.federation.EArgument": {
 			"c": grpcfed.NewCELFieldType(grpcfed.CELStringType, "C"),
 			"d": grpcfed.NewCELFieldType(grpcfed.CELStringType, "D"),
 		},
-		"grpc.federation.private.FArgument": {
+		"grpc.federation.private.org.federation.FArgument": {
 			"c": grpcfed.NewCELFieldType(grpcfed.CELStringType, "C"),
 			"d": grpcfed.NewCELFieldType(grpcfed.CELStringType, "D"),
 		},
-		"grpc.federation.private.GArgument":           {},
-		"grpc.federation.private.GetResponseArgument": {},
-		"grpc.federation.private.HArgument": {
+		"grpc.federation.private.org.federation.GArgument":           {},
+		"grpc.federation.private.org.federation.GetResponseArgument": {},
+		"grpc.federation.private.org.federation.HArgument": {
 			"e": grpcfed.NewCELFieldType(grpcfed.CELStringType, "E"),
 			"f": grpcfed.NewCELFieldType(grpcfed.CELStringType, "F"),
 			"g": grpcfed.NewCELFieldType(grpcfed.CELStringType, "G"),
 		},
-		"grpc.federation.private.IArgument": {},
-		"grpc.federation.private.JArgument": {
+		"grpc.federation.private.org.federation.IArgument": {},
+		"grpc.federation.private.org.federation.JArgument": {
 			"i": grpcfed.NewCELFieldType(grpcfed.CELStringType, "I"),
 		},
 	}
@@ -253,7 +253,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *F
 			Ab *AB
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.AArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.AArgument", req)}
 	/*
 		def {
 		  name: "aa"
@@ -369,7 +369,7 @@ func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.AAArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.AAArgument", req)}
 
 	// create a message value to be returned.
 	ret := &AA{}
@@ -405,7 +405,7 @@ func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ABArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.ABArgument", req)}
 
 	// create a message value to be returned.
 	ret := &AB{}
@@ -441,7 +441,7 @@ func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.BArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.BArgument", req)}
 
 	// create a message value to be returned.
 	ret := &B{}
@@ -477,7 +477,7 @@ func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CArgument", req)}
 
 	// create a message value to be returned.
 	ret := &C{}
@@ -513,7 +513,7 @@ func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.DArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.DArgument", req)}
 
 	// create a message value to be returned.
 	ret := &D{}
@@ -549,7 +549,7 @@ func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.EArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.EArgument", req)}
 
 	// create a message value to be returned.
 	ret := &E{}
@@ -585,7 +585,7 @@ func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.FArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.FArgument", req)}
 
 	// create a message value to be returned.
 	ret := &F{}
@@ -621,7 +621,7 @@ func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GArgument", req)}
 
 	// create a message value to be returned.
 	ret := &G{}
@@ -667,7 +667,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			J *J
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "a"
@@ -1253,7 +1253,7 @@ func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.HArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.HArgument", req)}
 
 	// create a message value to be returned.
 	ret := &H{}
@@ -1289,7 +1289,7 @@ func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.IArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.IArgument", req)}
 
 	// create a message value to be returned.
 	ret := &I{}
@@ -1325,7 +1325,7 @@ func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.JArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.JArgument", req)}
 
 	// create a message value to be returned.
 	ret := &J{}

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -143,12 +143,12 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id":          grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"a":           grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionA"), "A"),
 			"condition_b": grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionB"), "ConditionB"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"a":  grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionA"), "A"),
 			"b":  grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionB"), "B"),
@@ -228,7 +228,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -346,7 +346,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			TypeFed   PostType
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -129,13 +129,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
 	}
@@ -204,7 +204,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			XDef0 *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "_def0"
@@ -282,7 +282,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			XDef2 *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -449,7 +449,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -117,7 +117,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {
+		"grpc.federation.private.org.federation.GetResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -189,7 +189,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			Res     *content.GetContentResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -163,12 +163,12 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {},
-		"grpc.federation.private.SubArgument":         {},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.GetResponseArgument": {},
+		"grpc.federation.private.org.federation.SubArgument":         {},
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
-		"grpc.federation.private.UserIDArgument": {},
+		"grpc.federation.private.org.federation.UserIDArgument": {},
 	}
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
@@ -236,7 +236,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			User2 *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "uid"
@@ -457,7 +457,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			XDef2 *Sub
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -620,7 +620,7 @@ func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, r
 			XDef0 *Sub
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserIDArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserIDArgument", req)}
 	/*
 		def {
 		  name: "_def0"

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -154,18 +154,18 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.CastOneofArgument":                   {},
-		"grpc.federation.private.GetNoValueResponseArgument":          {},
-		"grpc.federation.private.GetResponseArgument":                 {},
-		"grpc.federation.private.MessageSelectionArgument":            {},
-		"grpc.federation.private.NestedMessageSelection_NestArgument": {},
-		"grpc.federation.private.NoValueSelectionArgument":            {},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.CastOneofArgument":                   {},
+		"grpc.federation.private.org.federation.GetNoValueResponseArgument":          {},
+		"grpc.federation.private.org.federation.GetResponseArgument":                 {},
+		"grpc.federation.private.org.federation.MessageSelectionArgument":            {},
+		"grpc.federation.private.org.federation.NestedMessageSelection_NestArgument": {},
+		"grpc.federation.private.org.federation.NoValueSelectionArgument":            {},
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 			"foo":     grpcfed.NewCELFieldType(grpcfed.CELIntType, "Foo"),
 			"bar":     grpcfed.NewCELFieldType(grpcfed.CELStringType, "Bar"),
 		},
-		"grpc.federation.private.UserSelectionArgument": {
+		"grpc.federation.private.org.federation.UserSelectionArgument": {
 			"value": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Value"),
 		},
 		"org.federation.MessageSelection": {
@@ -278,7 +278,7 @@ func (s *FederationService) resolve_Org_Federation_CastOneof(ctx context.Context
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CastOneofArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CastOneofArgument", req)}
 
 	// create a message value to be returned.
 	ret := &CastOneof{}
@@ -388,7 +388,7 @@ func (s *FederationService) resolve_Org_Federation_GetNoValueResponse(ctx contex
 			NoValueSel *NoValueSelection
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetNoValueResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetNoValueResponseArgument", req)}
 	/*
 		def {
 		  name: "no_value_sel"
@@ -462,7 +462,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			Sel       *UserSelection
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "sel"
@@ -708,7 +708,7 @@ func (s *FederationService) resolve_Org_Federation_MessageSelection(ctx context.
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.MessageSelectionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.MessageSelectionArgument", req)}
 
 	// create a message value to be returned.
 	ret := &MessageSelection{}
@@ -795,7 +795,7 @@ func (s *FederationService) resolve_Org_Federation_NestedMessageSelection_Nest(c
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.NestedMessageSelection_NestArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.NestedMessageSelection_NestArgument", req)}
 
 	// create a message value to be returned.
 	ret := &NestedMessageSelection_Nest{}
@@ -868,7 +868,7 @@ func (s *FederationService) resolve_Org_Federation_NoValueSelection(ctx context.
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.NoValueSelectionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.NoValueSelectionArgument", req)}
 
 	// create a message value to be returned.
 	ret := &NoValueSelection{}
@@ -942,7 +942,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			XDef0 *user.GetUserResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "_def0"
@@ -1074,7 +1074,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 			Uc *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserSelectionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserSelectionArgument", req)}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
 	req.Ua = value.vars.Ua

--- a/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
@@ -177,17 +177,17 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetNameResponseArgument":     {},
-		"grpc.federation.private.GetNameResponse_FooArgument": {},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.federation.GetNameResponseArgument":     {},
+		"grpc.federation.private.federation.GetNameResponse_FooArgument": {},
+		"grpc.federation.private.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.GetPostResponse_FooArgument": {},
-		"grpc.federation.private.PostArgument":                {},
-		"grpc.federation.private.ReactionArgument": {
+		"grpc.federation.private.federation.GetPostResponse_FooArgument": {},
+		"grpc.federation.private.federation.PostArgument":                {},
+		"grpc.federation.private.federation.ReactionArgument": {
 			"v": grpcfed.NewCELFieldType(grpcfed.CELIntType, "V"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.federation.UserArgument": {
 			"id":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"name": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Name"),
 		},
@@ -404,7 +404,7 @@ func (s *FederationService) resolve_Federation_GetNameResponse(ctx context.Conte
 			Foo *GetNameResponse_Foo
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetNameResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetNameResponseArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -489,7 +489,7 @@ func (s *FederationService) resolve_Federation_GetNameResponse_Foo(ctx context.C
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetNameResponse_FooArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetNameResponse_FooArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 
@@ -529,7 +529,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			P   *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponseArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -677,7 +677,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse_Foo(ctx context.C
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponse_FooArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponse_FooArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 
@@ -719,7 +719,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			U             *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.PostArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -1024,7 +1024,7 @@ func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req
 			Cmp bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ReactionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.ReactionArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -1114,7 +1114,7 @@ func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Fe
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.UserArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 
@@ -1475,17 +1475,17 @@ func NewPrivateService(cfg PrivateServiceConfig) (*PrivateService, error) {
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetNameResponseArgument":     {},
-		"grpc.federation.private.GetNameResponse_FooArgument": {},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.federation.GetNameResponseArgument":     {},
+		"grpc.federation.private.federation.GetNameResponse_FooArgument": {},
+		"grpc.federation.private.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.GetPostResponse_FooArgument": {},
-		"grpc.federation.private.PostArgument":                {},
-		"grpc.federation.private.ReactionArgument": {
+		"grpc.federation.private.federation.GetPostResponse_FooArgument": {},
+		"grpc.federation.private.federation.PostArgument":                {},
+		"grpc.federation.private.federation.ReactionArgument": {
 			"v": grpcfed.NewCELFieldType(grpcfed.CELIntType, "V"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.federation.UserArgument": {
 			"id":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"name": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Name"),
 		},
@@ -1815,7 +1815,7 @@ func (s *PrivateService) resolve_Federation_GetNameResponse(ctx context.Context,
 			Foo *GetNameResponse_Foo
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetNameResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetNameResponseArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -1900,7 +1900,7 @@ func (s *PrivateService) resolve_Federation_GetNameResponse_Foo(ctx context.Cont
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetNameResponse_FooArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetNameResponse_FooArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 
@@ -1940,7 +1940,7 @@ func (s *PrivateService) resolve_Federation_GetPostResponse(ctx context.Context,
 			P   *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponseArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -2088,7 +2088,7 @@ func (s *PrivateService) resolve_Federation_GetPostResponse_Foo(ctx context.Cont
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponse_FooArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponse_FooArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 
@@ -2130,7 +2130,7 @@ func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *Priva
 			U             *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.PostArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -2435,7 +2435,7 @@ func (s *PrivateService) resolve_Federation_Reaction(ctx context.Context, req *P
 			Cmp bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ReactionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.ReactionArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 	/*
@@ -2525,7 +2525,7 @@ func (s *PrivateService) resolve_Federation_User(ctx context.Context, req *Priva
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.UserArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 
@@ -2809,8 +2809,8 @@ func NewDebugService(cfg DebugServiceConfig) (*DebugService, error) {
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetStatusResponseArgument": {},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.federation.GetStatusResponseArgument": {},
+		"grpc.federation.private.federation.UserArgument": {
 			"id":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"name": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Name"),
 		},
@@ -2878,7 +2878,7 @@ func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context,
 			U *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetStatusResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetStatusResponseArgument", req)}
 	/*
 		def {
 		  name: "u"
@@ -2976,7 +2976,7 @@ func (s *DebugService) resolve_Federation_User(ctx context.Context, req *DebugSe
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.UserArgument", req)}
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/11_multi_service/federation/other_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/other_grpc_federation.pb.go
@@ -138,14 +138,14 @@ func NewOtherService(cfg OtherServiceConfig) (*OtherService, error) {
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {
+		"grpc.federation.private.federation.GetResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {},
-		"grpc.federation.private.ReactionArgument": {
+		"grpc.federation.private.federation.PostArgument": {},
+		"grpc.federation.private.federation.ReactionArgument": {
 			"v": grpcfed.NewCELFieldType(grpcfed.CELIntType, "V"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.federation.UserArgument": {
 			"id":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"name": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Name"),
 		},
@@ -216,7 +216,7 @@ func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *
 			P *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "p"
@@ -289,7 +289,7 @@ func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *OtherSe
 			U             *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "u"
@@ -592,7 +592,7 @@ func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *Oth
 			Cmp bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ReactionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.ReactionArgument", req)}
 	/*
 		def {
 		  name: "cmp"
@@ -680,7 +680,7 @@ func (s *OtherService) resolve_Federation_User(ctx context.Context, req *OtherSe
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.UserArgument", req)}
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/12_validation/federation/federation_grpc_federation.pb.go
+++ b/_examples/12_validation/federation/federation_grpc_federation.pb.go
@@ -128,16 +128,16 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.CustomHandlerMessageArgument": {
+		"grpc.federation.private.org.federation.CustomHandlerMessageArgument": {
 			"arg": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Arg"),
 		},
-		"grpc.federation.private.CustomMessageArgument": {
+		"grpc.federation.private.org.federation.CustomMessageArgument": {
 			"message": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Message"),
 		},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {},
+		"grpc.federation.private.org.federation.PostArgument": {},
 	}
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
@@ -203,7 +203,7 @@ func (s *FederationService) resolve_Org_Federation_CustomHandlerMessage(ctx cont
 			XDef0 bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CustomHandlerMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CustomHandlerMessageArgument", req)}
 	/*
 		def {
 		  name: "_def0"
@@ -272,7 +272,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CustomMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CustomMessageArgument", req)}
 
 	// create a message value to be returned.
 	ret := &CustomMessage{}
@@ -318,7 +318,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			XDef5               bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -1024,7 +1024,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -152,16 +152,16 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostsResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostsResponseArgument": {
 			"ids": grpcfed.NewCELFieldType(grpcfed.NewCELListType(grpcfed.CELStringType), "Ids"),
 		},
-		"grpc.federation.private.PostsArgument": {
+		"grpc.federation.private.org.federation.PostsArgument": {
 			"post_ids": grpcfed.NewCELFieldType(grpcfed.NewCELListType(grpcfed.CELStringType), "PostIds"),
 		},
-		"grpc.federation.private.Posts_PostItemArgument": {
+		"grpc.federation.private.org.federation.Posts_PostItemArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
 	}
@@ -233,7 +233,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 			Posts *Posts
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostsResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostsResponseArgument", req)}
 	/*
 		def {
 		  name: "posts"
@@ -324,7 +324,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 			Users             []*User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostsArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostsArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -841,7 +841,7 @@ func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Co
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.Posts_PostItemArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.Posts_PostItemArgument", req)}
 
 	// create a message value to be returned.
 	ret := &Posts_PostItem{}
@@ -879,7 +879,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			User *user.User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -131,13 +131,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
 	}
@@ -206,7 +206,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -295,7 +295,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			XDef5 bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -625,7 +625,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
@@ -115,8 +115,8 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.ExampleResponseArgument": {},
-		"grpc.federation.private.IsMatchResponseArgument": {
+		"grpc.federation.private.org.federation.ExampleResponseArgument": {},
+		"grpc.federation.private.org.federation.IsMatchResponseArgument": {
 			"expr":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Expr"),
 			"target": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Target"),
 		},
@@ -292,7 +292,7 @@ func (s *FederationService) resolve_Org_Federation_ExampleResponse(ctx context.C
 			V    []*pluginpb.Example
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ExampleResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.ExampleResponseArgument", req)}
 	/*
 		def {
 		  name: "exps"
@@ -461,7 +461,7 @@ func (s *FederationService) resolve_Org_Federation_IsMatchResponse(ctx context.C
 			Re      *pluginpb.Regexp
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.IsMatchResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.IsMatchResponseArgument", req)}
 	/*
 		def {
 		  name: "re"

--- a/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
@@ -110,7 +110,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {
+		"grpc.federation.private.org.federation.GetResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELIntType, "Id"),
 		},
 	}

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -142,19 +142,19 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.CustomMessageArgument": {
+		"grpc.federation.private.org.federation.CustomMessageArgument": {
 			"error_info": grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("grpc.federation.private.Error"), "ErrorInfo"),
 		},
-		"grpc.federation.private.GetPost2ResponseArgument": {
+		"grpc.federation.private.org.federation.GetPost2ResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.LocalizedMessageArgument": {
+		"grpc.federation.private.org.federation.LocalizedMessageArgument": {
 			"value": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Value"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -245,7 +245,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CustomMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CustomMessageArgument", req)}
 
 	// create a message value to be returned.
 	ret := &CustomMessage{}
@@ -283,7 +283,7 @@ func (s *FederationService) resolve_Org_Federation_GetPost2Response(ctx context.
 			XDef0 *post.GetPostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPost2ResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPost2ResponseArgument", req)}
 	/*
 		def {
 		  name: "_def0"
@@ -450,7 +450,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -533,7 +533,7 @@ func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.LocalizedMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.LocalizedMessageArgument", req)}
 
 	// create a message value to be returned.
 	ret := &LocalizedMessage{}
@@ -574,7 +574,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			XDef0ErrDetail0Msg0 *CustomMessage
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/_examples/18_load/federation/federation_grpc_federation.pb.go
+++ b/_examples/18_load/federation/federation_grpc_federation.pb.go
@@ -103,7 +103,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {},
+		"grpc.federation.private.org.federation.GetResponseArgument": {},
 	}
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
@@ -203,7 +203,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			IdFromPlugin   string
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "id_from_plugin"

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -120,10 +120,10 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -192,7 +192,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -258,7 +258,7 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 			XDef0 *post.GetPostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "_def0"

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -127,12 +127,12 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"a":  grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionA"), "A"),
 			"b":  grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionB"), "B"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"a":  grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionA"), "A"),
 			"b":  grpcfed.NewCELFieldType(grpcfed.NewCELObjectType("org.federation.GetPostRequest.ConditionB"), "B"),
@@ -209,7 +209,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -322,7 +322,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			Res  *post.GetPostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/generator/testdata/expected_async.go
+++ b/generator/testdata/expected_async.go
@@ -161,33 +161,33 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.AAArgument": {},
-		"grpc.federation.private.AArgument":  {},
-		"grpc.federation.private.ABArgument": {},
-		"grpc.federation.private.BArgument":  {},
-		"grpc.federation.private.CArgument": {
+		"grpc.federation.private.org.federation.AAArgument": {},
+		"grpc.federation.private.org.federation.AArgument":  {},
+		"grpc.federation.private.org.federation.ABArgument": {},
+		"grpc.federation.private.org.federation.BArgument":  {},
+		"grpc.federation.private.org.federation.CArgument": {
 			"a": grpcfed.NewCELFieldType(grpcfed.CELStringType, "A"),
 		},
-		"grpc.federation.private.DArgument": {
+		"grpc.federation.private.org.federation.DArgument": {
 			"b": grpcfed.NewCELFieldType(grpcfed.CELStringType, "B"),
 		},
-		"grpc.federation.private.EArgument": {
+		"grpc.federation.private.org.federation.EArgument": {
 			"c": grpcfed.NewCELFieldType(grpcfed.CELStringType, "C"),
 			"d": grpcfed.NewCELFieldType(grpcfed.CELStringType, "D"),
 		},
-		"grpc.federation.private.FArgument": {
+		"grpc.federation.private.org.federation.FArgument": {
 			"c": grpcfed.NewCELFieldType(grpcfed.CELStringType, "C"),
 			"d": grpcfed.NewCELFieldType(grpcfed.CELStringType, "D"),
 		},
-		"grpc.federation.private.GArgument":           {},
-		"grpc.federation.private.GetResponseArgument": {},
-		"grpc.federation.private.HArgument": {
+		"grpc.federation.private.org.federation.GArgument":           {},
+		"grpc.federation.private.org.federation.GetResponseArgument": {},
+		"grpc.federation.private.org.federation.HArgument": {
 			"e": grpcfed.NewCELFieldType(grpcfed.CELStringType, "E"),
 			"f": grpcfed.NewCELFieldType(grpcfed.CELStringType, "F"),
 			"g": grpcfed.NewCELFieldType(grpcfed.CELStringType, "G"),
 		},
-		"grpc.federation.private.IArgument": {},
-		"grpc.federation.private.JArgument": {
+		"grpc.federation.private.org.federation.IArgument": {},
+		"grpc.federation.private.org.federation.JArgument": {
 			"i": grpcfed.NewCELFieldType(grpcfed.CELStringType, "I"),
 		},
 	}
@@ -253,7 +253,7 @@ func (s *FederationService) resolve_Org_Federation_A(ctx context.Context, req *F
 			Ab *AB
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.AArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.AArgument", req)}
 	/*
 		def {
 		  name: "aa"
@@ -369,7 +369,7 @@ func (s *FederationService) resolve_Org_Federation_AA(ctx context.Context, req *
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.AAArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.AAArgument", req)}
 
 	// create a message value to be returned.
 	ret := &AA{}
@@ -405,7 +405,7 @@ func (s *FederationService) resolve_Org_Federation_AB(ctx context.Context, req *
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ABArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.ABArgument", req)}
 
 	// create a message value to be returned.
 	ret := &AB{}
@@ -441,7 +441,7 @@ func (s *FederationService) resolve_Org_Federation_B(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.BArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.BArgument", req)}
 
 	// create a message value to be returned.
 	ret := &B{}
@@ -477,7 +477,7 @@ func (s *FederationService) resolve_Org_Federation_C(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CArgument", req)}
 
 	// create a message value to be returned.
 	ret := &C{}
@@ -513,7 +513,7 @@ func (s *FederationService) resolve_Org_Federation_D(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.DArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.DArgument", req)}
 
 	// create a message value to be returned.
 	ret := &D{}
@@ -549,7 +549,7 @@ func (s *FederationService) resolve_Org_Federation_E(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.EArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.EArgument", req)}
 
 	// create a message value to be returned.
 	ret := &E{}
@@ -585,7 +585,7 @@ func (s *FederationService) resolve_Org_Federation_F(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.FArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.FArgument", req)}
 
 	// create a message value to be returned.
 	ret := &F{}
@@ -621,7 +621,7 @@ func (s *FederationService) resolve_Org_Federation_G(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GArgument", req)}
 
 	// create a message value to be returned.
 	ret := &G{}
@@ -667,7 +667,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			J *J
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "a"
@@ -1253,7 +1253,7 @@ func (s *FederationService) resolve_Org_Federation_H(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.HArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.HArgument", req)}
 
 	// create a message value to be returned.
 	ret := &H{}
@@ -1289,7 +1289,7 @@ func (s *FederationService) resolve_Org_Federation_I(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.IArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.IArgument", req)}
 
 	// create a message value to be returned.
 	ret := &I{}
@@ -1325,7 +1325,7 @@ func (s *FederationService) resolve_Org_Federation_J(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.JArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.JArgument", req)}
 
 	// create a message value to be returned.
 	ret := &J{}

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -129,13 +129,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
 	}
@@ -205,7 +205,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			XDef0 *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "_def0"
@@ -282,7 +282,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			XDef2 *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -449,7 +449,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -131,13 +131,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
 	}
@@ -207,7 +207,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -296,7 +296,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			XDef5 bool
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -626,7 +626,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -136,19 +136,19 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.CreatePostArgument": {
+		"grpc.federation.private.org.federation.CreatePostArgument": {
 			"title":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Title"),
 			"content": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Content"),
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 			"type":    grpcfed.NewCELFieldType(grpcfed.CELIntType, "Type"),
 		},
-		"grpc.federation.private.CreatePostResponseArgument": {
+		"grpc.federation.private.org.federation.CreatePostResponseArgument": {
 			"title":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Title"),
 			"content": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Content"),
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 			"type":    grpcfed.NewCELFieldType(grpcfed.CELIntType, "Type"),
 		},
-		"grpc.federation.private.UpdatePostResponseArgument": {
+		"grpc.federation.private.org.federation.UpdatePostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -250,7 +250,7 @@ func (s *FederationService) resolve_Org_Federation_CreatePost(ctx context.Contex
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CreatePostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CreatePostArgument", req)}
 
 	// create a message value to be returned.
 	ret := &CreatePost{}
@@ -341,7 +341,7 @@ func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx contex
 			Res *post.CreatePostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CreatePostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CreatePostResponseArgument", req)}
 	/*
 		def {
 		  name: "cp"
@@ -546,7 +546,7 @@ func (s *FederationService) resolve_Org_Federation_UpdatePostResponse(ctx contex
 			XDef0 *post.UpdatePostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UpdatePostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UpdatePostResponseArgument", req)}
 	/*
 		def {
 		  name: "_def0"

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -190,13 +190,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"id":      grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"title":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Title"),
 			"content": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Content"),
@@ -273,7 +273,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -359,7 +359,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			User *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -522,7 +522,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			U   *user.User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -135,16 +135,16 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.CustomMessageArgument": {
+		"grpc.federation.private.org.federation.CustomMessageArgument": {
 			"msg": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Msg"),
 		},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.LocalizedMessageArgument": {
+		"grpc.federation.private.org.federation.LocalizedMessageArgument": {
 			"value": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Value"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -213,7 +213,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CustomMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CustomMessageArgument", req)}
 
 	// create a message value to be returned.
 	ret := &CustomMessage{}
@@ -250,7 +250,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -333,7 +333,7 @@ func (s *FederationService) resolve_Org_Federation_LocalizedMessage(ctx context.
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.LocalizedMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.LocalizedMessageArgument", req)}
 
 	// create a message value to be returned.
 	ret := &LocalizedMessage{}
@@ -374,7 +374,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			XDef0ErrDetail0Msg0 *CustomMessage
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -167,16 +167,16 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostsResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostsResponseArgument": {
 			"ids": grpcfed.NewCELFieldType(grpcfed.NewCELListType(grpcfed.CELStringType), "Ids"),
 		},
-		"grpc.federation.private.PostsArgument": {
+		"grpc.federation.private.org.federation.PostsArgument": {
 			"post_ids": grpcfed.NewCELFieldType(grpcfed.NewCELListType(grpcfed.CELStringType), "PostIds"),
 		},
-		"grpc.federation.private.Posts_PostItemArgument": {
+		"grpc.federation.private.org.federation.Posts_PostItemArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
 	}
@@ -251,7 +251,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 			Posts *Posts
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostsResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostsResponseArgument", req)}
 	/*
 		def {
 		  name: "posts"
@@ -341,7 +341,7 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 			Users           []*User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostsArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostsArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -773,7 +773,7 @@ func (s *FederationService) resolve_Org_Federation_Posts_PostItem(ctx context.Co
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.Posts_PostItemArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.Posts_PostItemArgument", req)}
 
 	// create a message value to be returned.
 	ret := &Posts_PostItem{}
@@ -811,7 +811,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			User *user.User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/generator/testdata/expected_minimum.go
+++ b/generator/testdata/expected_minimum.go
@@ -111,7 +111,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"type": grpcfed.NewCELFieldType(grpcfed.CELIntType, "Type"),
 		},

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -163,12 +163,12 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {},
-		"grpc.federation.private.SubArgument":         {},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.GetResponseArgument": {},
+		"grpc.federation.private.org.federation.SubArgument":         {},
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
-		"grpc.federation.private.UserIDArgument": {},
+		"grpc.federation.private.org.federation.UserIDArgument": {},
 	}
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
@@ -238,7 +238,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			User2 *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "uid"
@@ -459,7 +459,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			XDef2 *Sub
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -622,7 +622,7 @@ func (s *FederationService) resolve_Org_Federation_UserID(ctx context.Context, r
 			XDef0 *Sub
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserIDArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserIDArgument", req)}
 	/*
 		def {
 		  name: "_def0"

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -133,12 +133,12 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetResponseArgument": {},
-		"grpc.federation.private.MArgument":           {},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.GetResponseArgument": {},
+		"grpc.federation.private.org.federation.MArgument":           {},
+		"grpc.federation.private.org.federation.UserArgument": {
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
-		"grpc.federation.private.UserSelectionArgument": {
+		"grpc.federation.private.org.federation.UserSelectionArgument": {
 			"value": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Value"),
 		},
 		"org.federation.UserSelection": {
@@ -215,7 +215,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 			Sel *UserSelection
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetResponseArgument", req)}
 	/*
 		def {
 		  name: "sel"
@@ -298,7 +298,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.MArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.MArgument", req)}
 
 	// create a message value to be returned.
 	ret := &M{}
@@ -335,7 +335,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			XDef0 *user.GetUserResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "_def0"
@@ -468,7 +468,7 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 			Uc *User
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserSelectionArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserSelectionArgument", req)}
 	/*
 		def {
 		  name: "m"

--- a/generator/testdata/expected_ref_env.go
+++ b/generator/testdata/expected_ref_env.go
@@ -138,7 +138,7 @@ func NewRefEnvService(cfg RefEnvServiceConfig) (*RefEnvService, error) {
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.ConstantArgument": {},
+		"grpc.federation.private.org.federation.ConstantArgument": {},
 		"grpc.federation.private.Env": {
 			"aaa": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Aaa"),
 			"bbb": grpcfed.NewCELFieldType(grpcfed.NewCELListType(grpcfed.CELIntType), "Bbb"),
@@ -244,7 +244,7 @@ func (s *RefEnvService) resolve_Org_Federation_Constant(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.ConstantArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.ConstantArgument", req)}
 	value.AddEnv(s.env)
 	value.AddServiceVariable(s.svcVar)
 

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -128,13 +128,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponse1Argument": {
+		"grpc.federation.private.org.federation.GetPostResponse1Argument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.GetPostResponse2Argument": {
+		"grpc.federation.private.org.federation.GetPostResponse2Argument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
 	}
@@ -228,7 +228,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponse1Argument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponse1Argument", req)}
 	/*
 		def {
 		  name: "post"
@@ -312,7 +312,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.
 			Post *Post
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponse2Argument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponse2Argument", req)}
 	/*
 		def {
 		  name: "post"
@@ -396,7 +396,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			Res *post.GetPostResponse
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -203,23 +203,23 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.MArgument": {
+		"grpc.federation.private.org.federation.MArgument": {
 			"x": grpcfed.NewCELFieldType(grpcfed.CELUintType, "X"),
 			"y": grpcfed.NewCELFieldType(grpcfed.CELIntType, "Y"),
 		},
-		"grpc.federation.private.PostArgument": {
+		"grpc.federation.private.org.federation.PostArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.UserArgument": {
+		"grpc.federation.private.org.federation.UserArgument": {
 			"id":      grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 			"title":   grpcfed.NewCELFieldType(grpcfed.CELStringType, "Title"),
 			"content": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Content"),
 			"user_id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "UserId"),
 		},
-		"grpc.federation.private.ZArgument": {},
+		"grpc.federation.private.org.federation.ZArgument": {},
 	}
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
@@ -299,7 +299,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			Uuid     *grpcfedcel.UUID
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -595,7 +595,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *F
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.MArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.MArgument", req)}
 
 	// create a message value to be returned.
 	ret := &M{}
@@ -649,7 +649,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 			Z    *Z
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 	/*
 		def {
 		  name: "res"
@@ -954,7 +954,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 			XDef2 *M
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.UserArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserArgument", req)}
 	/*
 		def {
 		  name: "res"

--- a/generator/testdata/expected_validation.go
+++ b/generator/testdata/expected_validation.go
@@ -106,13 +106,13 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		errorHandler = func(ctx context.Context, methodName string, err error) error { return err }
 	}
 	celTypeHelperFieldMap := grpcfed.CELTypeHelperFieldMap{
-		"grpc.federation.private.CustomMessageArgument": {
+		"grpc.federation.private.org.federation.CustomMessageArgument": {
 			"message": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Message"),
 		},
-		"grpc.federation.private.GetPostResponseArgument": {
+		"grpc.federation.private.org.federation.GetPostResponseArgument": {
 			"id": grpcfed.NewCELFieldType(grpcfed.CELStringType, "Id"),
 		},
-		"grpc.federation.private.PostArgument": {},
+		"grpc.federation.private.org.federation.PostArgument": {},
 	}
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
@@ -176,7 +176,7 @@ func (s *FederationService) resolve_Org_Federation_CustomMessage(ctx context.Con
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.CustomMessageArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.CustomMessageArgument", req)}
 
 	// create a message value to be returned.
 	ret := &CustomMessage{}
@@ -217,7 +217,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 			XDef2ErrDetail0Msg1 *CustomMessage
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.GetPostResponseArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.GetPostResponseArgument", req)}
 	/*
 		def {
 		  name: "post"
@@ -592,7 +592,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 		vars struct {
 		}
 	}
-	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.PostArgument", req)}
+	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.PostArgument", req)}
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/resolver/file.go
+++ b/resolver/file.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/mercari/grpc-federation/grpc/federation"
 )
 
 func (f *File) PackageName() string {
@@ -37,6 +39,10 @@ func (f *File) AllEnums() []*Enum {
 		enums = append(enums, msg.AllEnums()...)
 	}
 	return enums
+}
+
+func (f *File) PrivatePackageName() string {
+	return federation.PrivatePackageName + "." + f.PackageName()
 }
 
 func (f Files) FindByPackageName(pkg string) Files {

--- a/resolver/message.go
+++ b/resolver/message.go
@@ -3,7 +3,6 @@ package resolver
 import (
 	"strings"
 
-	"github.com/mercari/grpc-federation/grpc/federation"
 	grpcfedcel "github.com/mercari/grpc-federation/grpc/federation/cel"
 	"github.com/mercari/grpc-federation/types"
 )
@@ -64,7 +63,7 @@ func NewEnumSelectorType(trueType, falseType *Type) *Type {
 func newMessageArgument(msg *Message) *Message {
 	file := *msg.File
 	file.Package = &Package{
-		Name:  federation.PrivatePackageName,
+		Name:  file.PrivatePackageName(),
 		Files: Files{&file},
 	}
 	return &Message{

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -2020,7 +2020,7 @@ func (r *Resolver) resolveEnvVar(ctx *context, def *federation.EnvVar, builder *
 		mp.Name = cases.Title(language.Und).String(name) + "Entry"
 		file := ctx.file()
 		copied := *file
-		copied.Package = &Package{Name: federation.PrivatePackageName}
+		copied.Package = &Package{Name: file.PrivatePackageName()}
 		mp.File = &copied
 		r.cachedMessageMap[mp.FQDN()] = mp
 	}
@@ -4916,8 +4916,8 @@ func messageArgumentFileDescriptor(arg *Message) *descriptorpb.FileDescriptorPro
 		deps = append(deps, timeProtoFile)
 	}
 	return &descriptorpb.FileDescriptorProto{
-		Name:             proto.String(arg.Name),
-		Package:          proto.String(federation.PrivatePackageName),
+		Name:             proto.String(strings.Replace(arg.FQDN(), ".", "_", -1)),
+		Package:          proto.String(arg.PackageName()),
 		Dependency:       deps,
 		PublicDependency: desc.PublicDependency,
 		WeakDependency:   desc.WeakDependency,
@@ -4928,7 +4928,7 @@ func messageArgumentFileDescriptor(arg *Message) *descriptorpb.FileDescriptorPro
 func envVarsToMessage(file *File, name string, envVars []*EnvVar) *Message {
 	copied := *file
 	copied.Package = &Package{
-		Name: federation.PrivatePackageName,
+		Name: file.PrivatePackageName(),
 	}
 	envMsg := &Message{
 		File: &copied,
@@ -4946,7 +4946,7 @@ func envVarsToMessage(file *File, name string, envVars []*EnvVar) *Message {
 func svcVarsToMessage(file *File, name string, svcVars []*ServiceVariable) *Message {
 	copied := *file
 	copied.Package = &Package{
-		Name: federation.PrivatePackageName,
+		Name: file.PrivatePackageName(),
 	}
 	svcVarMsg := &Message{
 		File: &copied,
@@ -4991,7 +4991,7 @@ func dynamicMsgFileDescriptor(srcMsg *Message, fileName string) *descriptorpb.Fi
 	}
 	return &descriptorpb.FileDescriptorProto{
 		Name:             proto.String(fileName),
-		Package:          proto.String(federation.PrivatePackageName),
+		Package:          proto.String(srcMsg.PackageName()),
 		Dependency:       deps,
 		PublicDependency: desc.PublicDependency,
 		WeakDependency:   desc.WeakDependency,

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -701,18 +701,21 @@ func (r *Resolver) lookupPackageNameMapFromMessageArguments(args []*Argument) ma
 }
 
 func (r *Resolver) resultFiles(allFiles []*File) []*File {
-	fileMap := make(map[*File]struct{})
+	fileMap := make(map[string]struct{})
 	ret := make([]*File, 0, len(allFiles))
 	for _, file := range r.hasServiceOrPluginRuleFiles(allFiles) {
+		if _, exists := fileMap[file.Name]; exists {
+			continue
+		}
 		ret = append(ret, file)
-		fileMap[file] = struct{}{}
+		fileMap[file.Name] = struct{}{}
 
 		for _, samePkgFile := range r.samePackageFiles(file) {
-			if _, exists := fileMap[samePkgFile]; exists {
+			if _, exists := fileMap[samePkgFile.Name]; exists {
 				continue
 			}
 			ret = append(ret, samePkgFile)
-			fileMap[samePkgFile] = struct{}{}
+			fileMap[samePkgFile.Name] = struct{}{}
 		}
 	}
 	return ret


### PR DESCRIPTION
If multiple proto files are specified as arguments to protoc at the same time, there is a possibility of processing the same message defined in different packages. In this case, using only the `grpc.federation.private` package name would cause a name collision, so we generate the package name using the original package name. Additionally, since having the same file name in the Resolver results would cause an error, we ensure uniqueness by using the file name.