### PR TITLE
Fix code generator

### DIFF
--- a/generator/code_generator_test.go
+++ b/generator/code_generator_test.go
@@ -71,7 +71,7 @@ func TestCodeGenerate(t *testing.T) {
 				t.Fatalf("failed to get files. expected 1 but got %d", len(result.Files))
 			}
 			result.Files[0].Name = filepath.Base(result.Files[0].Name)
-			out, err := generator.NewCodeGenerator().Generate(result.Files[0], result.Enums)
+			out, err := generator.NewCodeGenerator().Generate(result.Files[0])
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -603,7 +603,7 @@ func (g *Generator) generateByGRPCFederation(r *PluginRequest) (*pluginpb.CodeGe
 
 	var resp pluginpb.CodeGeneratorResponse
 	for _, file := range result.Files {
-		out, err := NewCodeGenerator().Generate(file, result.Enums)
+		out, err := NewCodeGenerator().Generate(file)
 		if err != nil {
 			return nil, err
 		}
@@ -667,7 +667,7 @@ func CreateCodeGeneratorResponse(ctx context.Context, req *pluginpb.CodeGenerato
 
 	var resp pluginpb.CodeGeneratorResponse
 	for _, file := range result.Files {
-		out, err := NewCodeGenerator().Generate(file, result.Enums)
+		out, err := NewCodeGenerator().Generate(file)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Fix enum list of each File
  - When the enum list is generated by the code generator, all enums that have been processed are targeted, but in reality only the enums defined in the imported file can be used, so only the enum list that can be traced from the File is used. At this time, it was found that the same enum was registered in the enum list of File as several different instances, so it was modified to use the same instances.
- Fix alias name for import statement
  - When the package name conflicts, a new alias name is generated, but it was found that putting it directly into GoPackage.Name would be a destructive change and not good. Therefore, we have a `getAlias` function that determines the alias name through that function.