### PR TITLE
Variables with the same name but different types cause a compilation error

### DIFF
--- a/_examples/01_minimum/federation/federation_grpc_federation.pb.go
+++ b/_examples/01_minimum/federation/federation_grpc_federation.pb.go
@@ -22,9 +22,14 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type FederationService_Federation_GetPostResponseVariable struct {
+}
+
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
 type FederationService_Federation_GetPostResponseArgument struct {
 	Id string
+	FederationService_Federation_GetPostResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.

--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -47,31 +47,45 @@ var Item_ItemType_attrMap = grpcfed.EnumAttributeMap[Item_ItemType]{
 	},
 }
 
+// Federation_AVariable represents variable definitions in "federation.A".
+type FederationService_Federation_AVariable struct {
+	B *A_B
+}
+
 // Federation_AArgument is argument for "federation.A" message.
 type FederationService_Federation_AArgument struct {
-	B *A_B
+	FederationService_Federation_AVariable
+}
+
+// Federation_A_BVariable represents variable definitions in "federation.B".
+type FederationService_Federation_A_BVariable struct {
+	Bar *A_B_C
+	Foo *A_B_C
 }
 
 // Federation_A_BArgument is argument for "federation.B" message.
 type FederationService_Federation_A_BArgument struct {
-	Bar *A_B_C
-	Foo *A_B_C
+	FederationService_Federation_A_BVariable
+}
+
+// Federation_A_B_CVariable represents variable definitions in "federation.C".
+type FederationService_Federation_A_B_CVariable struct {
 }
 
 // Federation_A_B_CArgument is argument for "federation.C" message.
 type FederationService_Federation_A_B_CArgument struct {
 	Type string
+	FederationService_Federation_A_B_CVariable
 }
 
-// Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type FederationService_Federation_GetPostResponseArgument struct {
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type FederationService_Federation_GetPostResponseVariable struct {
 	A            *A
 	Date         *grpcfedcel.Time
 	E            Item_ItemType
 	FixedRand    *grpcfedcel.Rand
 	Flatten      []int64
 	Floor        float64
-	Id           string
 	JpTime       *grpcfedcel.Time
 	Loc          *grpcfedcel.Location
 	MapValue     map[int64]string
@@ -90,22 +104,38 @@ type FederationService_Federation_GetPostResponseArgument struct {
 	Value1       string
 }
 
-// Federation_PostArgument is argument for "federation.Post" message.
-type FederationService_Federation_PostArgument struct {
-	Id   string
+// Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
+type FederationService_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Federation_GetPostResponseVariable
+}
+
+// Federation_PostVariable represents variable definitions in "federation.Post".
+type FederationService_Federation_PostVariable struct {
 	Post *post.Post
 	Res  *post.GetPostResponse
 	User *User
+}
+
+// Federation_PostArgument is argument for "federation.Post" message.
+type FederationService_Federation_PostArgument struct {
+	Id string
+	FederationService_Federation_PostVariable
+}
+
+// Federation_UserVariable represents variable definitions in "federation.User".
+type FederationService_Federation_UserVariable struct {
+	Res  *user.GetUserResponse
+	User *user.User
 }
 
 // Federation_UserArgument is argument for "federation.User" message.
 type FederationService_Federation_UserArgument struct {
 	Content string
 	Id      string
-	Res     *user.GetUserResponse
 	Title   string
-	User    *user.User
 	UserId  string
+	FederationService_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -334,7 +364,7 @@ func (s *FederationService) resolve_Federation_A(ctx context.Context, req *Feder
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.B = value.vars.B
+	req.FederationService_Federation_AVariable.B = value.vars.B
 
 	// create a message value to be returned.
 	ret := &A{}
@@ -564,8 +594,8 @@ func (s *FederationService) resolve_Federation_A_B(ctx context.Context, req *Fed
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Bar = value.vars.Bar
-	req.Foo = value.vars.Foo
+	req.FederationService_Federation_A_BVariable.Bar = value.vars.Bar
+	req.FederationService_Federation_A_BVariable.Foo = value.vars.Foo
 
 	// create a message value to be returned.
 	ret := &A_B{}
@@ -1347,28 +1377,28 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.A = value.vars.A
-	req.Date = value.vars.Date
-	req.E = value.vars.E
-	req.FixedRand = value.vars.FixedRand
-	req.Flatten = value.vars.Flatten
-	req.Floor = value.vars.Floor
-	req.JpTime = value.vars.JpTime
-	req.Loc = value.vars.Loc
-	req.MapValue = value.vars.MapValue
-	req.NullValue = value.vars.NullValue
-	req.ParseFloat = value.vars.ParseFloat
-	req.Post = value.vars.Post
-	req.Pow = value.vars.Pow
-	req.RandSource = value.vars.RandSource
-	req.SortedItems = value.vars.SortedItems
-	req.SortedValues = value.vars.SortedValues
-	req.SqrtDouble = value.vars.SqrtDouble
-	req.SqrtInt = value.vars.SqrtInt
-	req.StringsJoin = value.vars.StringsJoin
-	req.Url = value.vars.Url
-	req.Uuid = value.vars.Uuid
-	req.Value1 = value.vars.Value1
+	req.FederationService_Federation_GetPostResponseVariable.A = value.vars.A
+	req.FederationService_Federation_GetPostResponseVariable.Date = value.vars.Date
+	req.FederationService_Federation_GetPostResponseVariable.E = value.vars.E
+	req.FederationService_Federation_GetPostResponseVariable.FixedRand = value.vars.FixedRand
+	req.FederationService_Federation_GetPostResponseVariable.Flatten = value.vars.Flatten
+	req.FederationService_Federation_GetPostResponseVariable.Floor = value.vars.Floor
+	req.FederationService_Federation_GetPostResponseVariable.JpTime = value.vars.JpTime
+	req.FederationService_Federation_GetPostResponseVariable.Loc = value.vars.Loc
+	req.FederationService_Federation_GetPostResponseVariable.MapValue = value.vars.MapValue
+	req.FederationService_Federation_GetPostResponseVariable.NullValue = value.vars.NullValue
+	req.FederationService_Federation_GetPostResponseVariable.ParseFloat = value.vars.ParseFloat
+	req.FederationService_Federation_GetPostResponseVariable.Post = value.vars.Post
+	req.FederationService_Federation_GetPostResponseVariable.Pow = value.vars.Pow
+	req.FederationService_Federation_GetPostResponseVariable.RandSource = value.vars.RandSource
+	req.FederationService_Federation_GetPostResponseVariable.SortedItems = value.vars.SortedItems
+	req.FederationService_Federation_GetPostResponseVariable.SortedValues = value.vars.SortedValues
+	req.FederationService_Federation_GetPostResponseVariable.SqrtDouble = value.vars.SqrtDouble
+	req.FederationService_Federation_GetPostResponseVariable.SqrtInt = value.vars.SqrtInt
+	req.FederationService_Federation_GetPostResponseVariable.StringsJoin = value.vars.StringsJoin
+	req.FederationService_Federation_GetPostResponseVariable.Url = value.vars.Url
+	req.FederationService_Federation_GetPostResponseVariable.Uuid = value.vars.Uuid
+	req.FederationService_Federation_GetPostResponseVariable.Value1 = value.vars.Value1
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -2125,9 +2155,9 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.User = value.vars.User
+	req.FederationService_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Federation_PostVariable.User = value.vars.User
 
 	// create a message value to be returned.
 	ret := &Post{}
@@ -2280,8 +2310,8 @@ func (s *FederationService) resolve_Federation_User(ctx context.Context, req *Fe
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.User = value.vars.User
+	req.FederationService_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Federation_UserVariable.User = value.vars.User
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -26,21 +26,30 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Federation_V2Dev_ForNamelessVariable represents variable definitions in "federation.v2dev.ForNameless".
+type FederationV2DevService_Federation_V2Dev_ForNamelessVariable struct {
+}
+
 // Federation_V2Dev_ForNamelessArgument is argument for "federation.v2dev.ForNameless" message.
 type FederationV2DevService_Federation_V2Dev_ForNamelessArgument struct {
 	Bar string
+	FederationV2DevService_Federation_V2Dev_ForNamelessVariable
 }
 
-// Federation_V2Dev_GetPostV2DevResponseArgument is argument for "federation.v2dev.GetPostV2devResponse" message.
-type FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseArgument struct {
-	Id   string
+// Federation_V2Dev_GetPostV2DevResponseVariable represents variable definitions in "federation.v2dev.GetPostV2devResponse".
+type FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseVariable struct {
 	Post *PostV2Dev
 	R    *Ref
 }
 
-// Federation_V2Dev_PostV2DevArgument is argument for "federation.v2dev.PostV2dev" message.
-type FederationV2DevService_Federation_V2Dev_PostV2DevArgument struct {
-	Id        string
+// Federation_V2Dev_GetPostV2DevResponseArgument is argument for "federation.v2dev.GetPostV2devResponse" message.
+type FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseArgument struct {
+	Id string
+	FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseVariable
+}
+
+// Federation_V2Dev_PostV2DevVariable represents variable definitions in "federation.v2dev.PostV2dev".
+type FederationV2DevService_Federation_V2Dev_PostV2DevVariable struct {
 	NullCheck bool
 	Post      *post.Post
 	Res       *post.GetPostResponse
@@ -51,32 +60,58 @@ type FederationV2DevService_Federation_V2Dev_PostV2DevArgument struct {
 	XDef7     bool
 }
 
+// Federation_V2Dev_PostV2DevArgument is argument for "federation.v2dev.PostV2dev" message.
+type FederationV2DevService_Federation_V2Dev_PostV2DevArgument struct {
+	Id string
+	FederationV2DevService_Federation_V2Dev_PostV2DevVariable
+}
+
 // Federation_V2Dev_PostV2Dev_UserArgument is custom resolver's argument for "user" field of "federation.v2dev.PostV2dev" message.
 type FederationV2DevService_Federation_V2Dev_PostV2Dev_UserArgument struct {
 	*FederationV2DevService_Federation_V2Dev_PostV2DevArgument
 }
 
+// Federation_V2Dev_RefVariable represents variable definitions in "federation.v2dev.Ref".
+type FederationV2DevService_Federation_V2Dev_RefVariable struct {
+}
+
 // Federation_V2Dev_RefArgument is argument for "federation.v2dev.Ref" message.
 type FederationV2DevService_Federation_V2Dev_RefArgument struct {
+	FederationV2DevService_Federation_V2Dev_RefVariable
+}
+
+// Federation_V2Dev_TypedNilVariable represents variable definitions in "federation.v2dev.TypedNil".
+type FederationV2DevService_Federation_V2Dev_TypedNilVariable struct {
 }
 
 // Federation_V2Dev_TypedNilArgument is argument for "federation.v2dev.TypedNil" message.
 type FederationV2DevService_Federation_V2Dev_TypedNilArgument struct {
+	FederationV2DevService_Federation_V2Dev_TypedNilVariable
+}
+
+// Federation_V2Dev_UnusedVariable represents variable definitions in "federation.v2dev.Unused".
+type FederationV2DevService_Federation_V2Dev_UnusedVariable struct {
 }
 
 // Federation_V2Dev_UnusedArgument is argument for "federation.v2dev.Unused" message.
 type FederationV2DevService_Federation_V2Dev_UnusedArgument struct {
 	Foo string
+	FederationV2DevService_Federation_V2Dev_UnusedVariable
+}
+
+// Federation_V2Dev_UserVariable represents variable definitions in "federation.v2dev.User".
+type FederationV2DevService_Federation_V2Dev_UserVariable struct {
+	Res *user.GetUserResponse
+	U   *user.User
 }
 
 // Federation_V2Dev_UserArgument is argument for "federation.v2dev.User" message.
 type FederationV2DevService_Federation_V2Dev_UserArgument struct {
 	Content string
 	Id      string
-	Res     *user.GetUserResponse
 	Title   string
-	U       *user.User
 	UserId  string
+	FederationV2DevService_Federation_V2Dev_UserVariable
 }
 
 // Federation_V2Dev_User_NameArgument is custom resolver's argument for "name" field of "federation.v2dev.User" message.
@@ -495,8 +530,8 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_GetPostV2DevResponse(c
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.R = value.vars.R
+	req.FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseVariable.Post = value.vars.Post
+	req.FederationV2DevService_Federation_V2Dev_GetPostV2DevResponseVariable.R = value.vars.R
 
 	// create a message value to be returned.
 	ret := &GetPostV2DevResponse{}
@@ -943,14 +978,14 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_PostV2Dev(ctx context.
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.NullCheck = value.vars.NullCheck
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.TypedNil = value.vars.TypedNil
-	req.Unused = value.vars.Unused
-	req.User = value.vars.User
-	req.XDef4 = value.vars.XDef4
-	req.XDef7 = value.vars.XDef7
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.NullCheck = value.vars.NullCheck
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.Post = value.vars.Post
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.Res = value.vars.Res
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.TypedNil = value.vars.TypedNil
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.Unused = value.vars.Unused
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.User = value.vars.User
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.XDef4 = value.vars.XDef4
+	req.FederationV2DevService_Federation_V2Dev_PostV2DevVariable.XDef7 = value.vars.XDef7
 
 	// create a message value to be returned.
 	ret := &PostV2Dev{}
@@ -1156,8 +1191,8 @@ func (s *FederationV2DevService) resolve_Federation_V2Dev_User(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.U = value.vars.U
+	req.FederationV2DevService_Federation_V2Dev_UserVariable.Res = value.vars.Res
+	req.FederationV2DevService_Federation_V2Dev_UserVariable.U = value.vars.U
 
 	// create a message value to be returned.
 	// `custom_resolver = true` in "grpc.federation.message" option.

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -25,22 +25,37 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type FederationService_Federation_GetPostResponseVariable struct {
+	Post *Post
+}
+
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
 type FederationService_Federation_GetPostResponseArgument struct {
-	Id   string
-	Post *Post
+	Id string
+	FederationService_Federation_GetPostResponseVariable
+}
+
+// Federation_PostVariable represents variable definitions in "federation.Post".
+type FederationService_Federation_PostVariable struct {
+	Post *post.Post
+	Res  *post.GetPostResponse
 }
 
 // Federation_PostArgument is argument for "federation.Post" message.
 type FederationService_Federation_PostArgument struct {
-	Id   string
-	Post *post.Post
-	Res  *post.GetPostResponse
+	Id string
+	FederationService_Federation_PostVariable
+}
+
+// Federation_UpdatePostResponseVariable represents variable definitions in "federation.UpdatePostResponse".
+type FederationService_Federation_UpdatePostResponseVariable struct {
 }
 
 // Federation_UpdatePostResponseArgument is argument for "federation.UpdatePostResponse" message.
 type FederationService_Federation_UpdatePostResponseArgument struct {
 	Id string
+	FederationService_Federation_UpdatePostResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -298,7 +313,7 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -410,8 +425,8 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
+	req.FederationService_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Federation_PostVariable.Res = value.vars.Res
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/_examples/05_async/federation/federation_grpc_federation.pb.go
+++ b/_examples/05_async/federation/federation_grpc_federation.pb.go
@@ -22,50 +22,95 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_AAVariable represents variable definitions in "org.federation.AA".
+type FederationService_Org_Federation_AAVariable struct {
+}
+
 // Org_Federation_AAArgument is argument for "org.federation.AA" message.
 type FederationService_Org_Federation_AAArgument struct {
+	FederationService_Org_Federation_AAVariable
+}
+
+// Org_Federation_AVariable represents variable definitions in "org.federation.A".
+type FederationService_Org_Federation_AVariable struct {
 }
 
 // Org_Federation_AArgument is argument for "org.federation.A" message.
 type FederationService_Org_Federation_AArgument struct {
+	FederationService_Org_Federation_AVariable
+}
+
+// Org_Federation_ABVariable represents variable definitions in "org.federation.AB".
+type FederationService_Org_Federation_ABVariable struct {
 }
 
 // Org_Federation_ABArgument is argument for "org.federation.AB" message.
 type FederationService_Org_Federation_ABArgument struct {
+	FederationService_Org_Federation_ABVariable
+}
+
+// Org_Federation_BVariable represents variable definitions in "org.federation.B".
+type FederationService_Org_Federation_BVariable struct {
 }
 
 // Org_Federation_BArgument is argument for "org.federation.B" message.
 type FederationService_Org_Federation_BArgument struct {
+	FederationService_Org_Federation_BVariable
+}
+
+// Org_Federation_CVariable represents variable definitions in "org.federation.C".
+type FederationService_Org_Federation_CVariable struct {
 }
 
 // Org_Federation_CArgument is argument for "org.federation.C" message.
 type FederationService_Org_Federation_CArgument struct {
 	A string
+	FederationService_Org_Federation_CVariable
+}
+
+// Org_Federation_DVariable represents variable definitions in "org.federation.D".
+type FederationService_Org_Federation_DVariable struct {
 }
 
 // Org_Federation_DArgument is argument for "org.federation.D" message.
 type FederationService_Org_Federation_DArgument struct {
 	B string
+	FederationService_Org_Federation_DVariable
+}
+
+// Org_Federation_EVariable represents variable definitions in "org.federation.E".
+type FederationService_Org_Federation_EVariable struct {
 }
 
 // Org_Federation_EArgument is argument for "org.federation.E" message.
 type FederationService_Org_Federation_EArgument struct {
 	C string
 	D string
+	FederationService_Org_Federation_EVariable
+}
+
+// Org_Federation_FVariable represents variable definitions in "org.federation.F".
+type FederationService_Org_Federation_FVariable struct {
 }
 
 // Org_Federation_FArgument is argument for "org.federation.F" message.
 type FederationService_Org_Federation_FArgument struct {
 	C string
 	D string
+	FederationService_Org_Federation_FVariable
+}
+
+// Org_Federation_GVariable represents variable definitions in "org.federation.G".
+type FederationService_Org_Federation_GVariable struct {
 }
 
 // Org_Federation_GArgument is argument for "org.federation.G" message.
 type FederationService_Org_Federation_GArgument struct {
+	FederationService_Org_Federation_GVariable
 }
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	A *A
 	B *B
 	C *C
@@ -78,20 +123,40 @@ type FederationService_Org_Federation_GetResponseArgument struct {
 	J *J
 }
 
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
+	FederationService_Org_Federation_GetResponseVariable
+}
+
+// Org_Federation_HVariable represents variable definitions in "org.federation.H".
+type FederationService_Org_Federation_HVariable struct {
+}
+
 // Org_Federation_HArgument is argument for "org.federation.H" message.
 type FederationService_Org_Federation_HArgument struct {
 	E string
 	F string
 	G string
+	FederationService_Org_Federation_HVariable
+}
+
+// Org_Federation_IVariable represents variable definitions in "org.federation.I".
+type FederationService_Org_Federation_IVariable struct {
 }
 
 // Org_Federation_IArgument is argument for "org.federation.I" message.
 type FederationService_Org_Federation_IArgument struct {
+	FederationService_Org_Federation_IVariable
+}
+
+// Org_Federation_JVariable represents variable definitions in "org.federation.J".
+type FederationService_Org_Federation_JVariable struct {
 }
 
 // Org_Federation_JArgument is argument for "org.federation.J" message.
 type FederationService_Org_Federation_JArgument struct {
 	I string
+	FederationService_Org_Federation_JVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -1203,16 +1268,16 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.A = value.vars.A
-	req.B = value.vars.B
-	req.C = value.vars.C
-	req.D = value.vars.D
-	req.E = value.vars.E
-	req.F = value.vars.F
-	req.G = value.vars.G
-	req.H = value.vars.H
-	req.I = value.vars.I
-	req.J = value.vars.J
+	req.FederationService_Org_Federation_GetResponseVariable.A = value.vars.A
+	req.FederationService_Org_Federation_GetResponseVariable.B = value.vars.B
+	req.FederationService_Org_Federation_GetResponseVariable.C = value.vars.C
+	req.FederationService_Org_Federation_GetResponseVariable.D = value.vars.D
+	req.FederationService_Org_Federation_GetResponseVariable.E = value.vars.E
+	req.FederationService_Org_Federation_GetResponseVariable.F = value.vars.F
+	req.FederationService_Org_Federation_GetResponseVariable.G = value.vars.G
+	req.FederationService_Org_Federation_GetResponseVariable.H = value.vars.H
+	req.FederationService_Org_Federation_GetResponseVariable.I = value.vars.I
+	req.FederationService_Org_Federation_GetResponseVariable.J = value.vars.J
 
 	// create a message value to be returned.
 	ret := &GetResponse{}

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -25,26 +25,36 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
+	Post *Post
+}
+
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
 type FederationService_Org_Federation_GetPostResponseArgument struct {
 	A          *GetPostRequest_ConditionA
 	ConditionB *GetPostRequest_ConditionB
 	Id         string
-	Post       *Post
+	FederationService_Org_Federation_GetPostResponseVariable
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
-	A         *GetPostRequest_ConditionA
-	B         *GetPostRequest_ConditionB
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Data2     *post1.PostData
 	DataType  *grpcfedcel.EnumSelector
 	DataType2 *grpcfedcel.EnumSelector
-	Id        string
 	Post      *post.Post
 	Res       *post.GetPostResponse
 	Res2      *post1.GetPostResponse
 	TypeFed   PostType
+}
+
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	A  *GetPostRequest_ConditionA
+	B  *GetPostRequest_ConditionB
+	Id string
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -311,7 +321,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -694,13 +704,13 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Data2 = value.vars.Data2
-	req.DataType = value.vars.DataType
-	req.DataType2 = value.vars.DataType2
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.Res2 = value.vars.Res2
-	req.TypeFed = value.vars.TypeFed
+	req.FederationService_Org_Federation_PostVariable.Data2 = value.vars.Data2
+	req.FederationService_Org_Federation_PostVariable.DataType = value.vars.DataType
+	req.FederationService_Org_Federation_PostVariable.DataType2 = value.vars.DataType2
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.Res2 = value.vars.Res2
+	req.FederationService_Org_Federation_PostVariable.TypeFed = value.vars.TypeFed
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -24,23 +24,38 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id    string
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	XDef0 *Post
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
-	Id    string
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Res   *post.GetPostResponse
 	XDef1 *post.Post
 	XDef2 *User
 }
 
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+}
+
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	UserId string
+	FederationService_Org_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -260,7 +275,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.XDef0 = value.vars.XDef0
+	req.FederationService_Org_Federation_GetPostResponseVariable.XDef0 = value.vars.XDef0
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -428,9 +443,9 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.XDef1 = value.vars.XDef1
-	req.XDef2 = value.vars.XDef2
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.XDef1 = value.vars.XDef1
+	req.FederationService_Org_Federation_PostVariable.XDef2 = value.vars.XDef2
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -24,11 +24,16 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
+	Content *content.Content
+	Res     *content.GetContentResponse
+}
+
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
 type FederationService_Org_Federation_GetResponseArgument struct {
-	Content *content.Content
-	Id      string
-	Res     *content.GetContentResponse
+	Id string
+	FederationService_Org_Federation_GetResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -714,8 +719,8 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Content = value.vars.Content
-	req.Res = value.vars.Res
+	req.FederationService_Org_Federation_GetResponseVariable.Content = value.vars.Content
+	req.FederationService_Org_Federation_GetResponseVariable.Res = value.vars.Res
 
 	// create a message value to be returned.
 	ret := &GetResponse{}

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -24,27 +24,47 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	Uid   *UserID
 	User  *User
 	User2 *User
 }
 
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
+	FederationService_Org_Federation_GetResponseVariable
+}
+
+// Org_Federation_SubVariable represents variable definitions in "org.federation.Sub".
+type FederationService_Org_Federation_SubVariable struct {
+}
+
 // Org_Federation_SubArgument is argument for "org.federation.Sub" message.
 type FederationService_Org_Federation_SubArgument struct {
+	FederationService_Org_Federation_SubVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+	Res   *user.GetUserResponse
+	User  *user.User
+	XDef2 *Sub
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
-	Res    *user.GetUserResponse
-	User   *user.User
 	UserId string
-	XDef2  *Sub
+	FederationService_Org_Federation_UserVariable
+}
+
+// Org_Federation_UserIDVariable represents variable definitions in "org.federation.UserID".
+type FederationService_Org_Federation_UserIDVariable struct {
 }
 
 // Org_Federation_UserIDArgument is argument for "org.federation.UserID" message.
 type FederationService_Org_Federation_UserIDArgument struct {
+	FederationService_Org_Federation_UserIDVariable
 }
 
 // Org_Federation_User_NameArgument is custom resolver's argument for "name" field of "org.federation.User" message.
@@ -390,9 +410,9 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Uid = value.vars.Uid
-	req.User = value.vars.User
-	req.User2 = value.vars.User2
+	req.FederationService_Org_Federation_GetResponseVariable.Uid = value.vars.Uid
+	req.FederationService_Org_Federation_GetResponseVariable.User = value.vars.User
+	req.FederationService_Org_Federation_GetResponseVariable.User2 = value.vars.User2
 
 	// create a message value to be returned.
 	ret := &GetResponse{}
@@ -589,9 +609,9 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.User = value.vars.User
-	req.XDef2 = value.vars.XDef2
+	req.FederationService_Org_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_UserVariable.User = value.vars.User
+	req.FederationService_Org_Federation_UserVariable.XDef2 = value.vars.XDef2
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -24,33 +24,67 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_CastOneofVariable represents variable definitions in "org.federation.CastOneof".
+type FederationService_Org_Federation_CastOneofVariable struct {
+}
+
 // Org_Federation_CastOneofArgument is argument for "org.federation.CastOneof" message.
 type FederationService_Org_Federation_CastOneofArgument struct {
+	FederationService_Org_Federation_CastOneofVariable
+}
+
+// Org_Federation_GetNoValueResponseVariable represents variable definitions in "org.federation.GetNoValueResponse".
+type FederationService_Org_Federation_GetNoValueResponseVariable struct {
+	NoValueSel *NoValueSelection
 }
 
 // Org_Federation_GetNoValueResponseArgument is argument for "org.federation.GetNoValueResponse" message.
 type FederationService_Org_Federation_GetNoValueResponseArgument struct {
-	NoValueSel *NoValueSelection
+	FederationService_Org_Federation_GetNoValueResponseVariable
 }
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	CastOneof *CastOneof
 	MsgSel    *MessageSelection
 	NestedMsg *NestedMessageSelection_Nest
 	Sel       *UserSelection
 }
 
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
+	FederationService_Org_Federation_GetResponseVariable
+}
+
+// Org_Federation_MessageSelectionVariable represents variable definitions in "org.federation.MessageSelection".
+type FederationService_Org_Federation_MessageSelectionVariable struct {
+}
+
 // Org_Federation_MessageSelectionArgument is argument for "org.federation.MessageSelection" message.
 type FederationService_Org_Federation_MessageSelectionArgument struct {
+	FederationService_Org_Federation_MessageSelectionVariable
+}
+
+// Org_Federation_NestedMessageSelection_NestVariable represents variable definitions in "org.federation.Nest".
+type FederationService_Org_Federation_NestedMessageSelection_NestVariable struct {
 }
 
 // Org_Federation_NestedMessageSelection_NestArgument is argument for "org.federation.Nest" message.
 type FederationService_Org_Federation_NestedMessageSelection_NestArgument struct {
+	FederationService_Org_Federation_NestedMessageSelection_NestVariable
+}
+
+// Org_Federation_NoValueSelectionVariable represents variable definitions in "org.federation.NoValueSelection".
+type FederationService_Org_Federation_NoValueSelectionVariable struct {
 }
 
 // Org_Federation_NoValueSelectionArgument is argument for "org.federation.NoValueSelection" message.
 type FederationService_Org_Federation_NoValueSelectionArgument struct {
+	FederationService_Org_Federation_NoValueSelectionVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
@@ -58,14 +92,20 @@ type FederationService_Org_Federation_UserArgument struct {
 	Bar    string
 	Foo    int64
 	UserId string
+	FederationService_Org_Federation_UserVariable
+}
+
+// Org_Federation_UserSelectionVariable represents variable definitions in "org.federation.UserSelection".
+type FederationService_Org_Federation_UserSelectionVariable struct {
+	Ua *User
+	Ub *User
+	Uc *User
 }
 
 // Org_Federation_UserSelectionArgument is argument for "org.federation.UserSelection" message.
 type FederationService_Org_Federation_UserSelectionArgument struct {
-	Ua    *User
-	Ub    *User
-	Uc    *User
 	Value string
+	FederationService_Org_Federation_UserSelectionVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -437,7 +477,7 @@ func (s *FederationService) resolve_Org_Federation_GetNoValueResponse(ctx contex
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.NoValueSel = value.vars.NoValueSel
+	req.FederationService_Org_Federation_GetNoValueResponseVariable.NoValueSel = value.vars.NoValueSel
 
 	// create a message value to be returned.
 	ret := &GetNoValueResponse{}
@@ -645,10 +685,10 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.CastOneof = value.vars.CastOneof
-	req.MsgSel = value.vars.MsgSel
-	req.NestedMsg = value.vars.NestedMsg
-	req.Sel = value.vars.Sel
+	req.FederationService_Org_Federation_GetResponseVariable.CastOneof = value.vars.CastOneof
+	req.FederationService_Org_Federation_GetResponseVariable.MsgSel = value.vars.MsgSel
+	req.FederationService_Org_Federation_GetResponseVariable.NestedMsg = value.vars.NestedMsg
+	req.FederationService_Org_Federation_GetResponseVariable.Sel = value.vars.Sel
 
 	// create a message value to be returned.
 	ret := &GetResponse{}
@@ -1092,9 +1132,9 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 	value := &localValueType{LocalValue: grpcfed.NewLocalValue(ctx, s.celEnvOpts, "grpc.federation.private.org.federation.UserSelectionArgument", req)}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Ua = value.vars.Ua
-	req.Ub = value.vars.Ub
-	req.Uc = value.vars.Uc
+	req.FederationService_Org_Federation_UserSelectionVariable.Ua = value.vars.Ua
+	req.FederationService_Org_Federation_UserSelectionVariable.Ub = value.vars.Ub
+	req.FederationService_Org_Federation_UserSelectionVariable.Uc = value.vars.Uc
 
 	// create a message value to be returned.
 	ret := &UserSelection{}

--- a/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
@@ -24,44 +24,79 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Federation_GetNameResponseVariable represents variable definitions in "federation.GetNameResponse".
+type FederationService_Federation_GetNameResponseVariable struct {
+	Foo *GetNameResponse_Foo
+}
+
 // Federation_GetNameResponseArgument is argument for "federation.GetNameResponse" message.
 type FederationService_Federation_GetNameResponseArgument struct {
-	Foo *GetNameResponse_Foo
+	FederationService_Federation_GetNameResponseVariable
+}
+
+// Federation_GetNameResponse_FooVariable represents variable definitions in "federation.Foo".
+type FederationService_Federation_GetNameResponse_FooVariable struct {
 }
 
 // Federation_GetNameResponse_FooArgument is argument for "federation.Foo" message.
 type FederationService_Federation_GetNameResponse_FooArgument struct {
+	FederationService_Federation_GetNameResponse_FooVariable
+}
+
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type FederationService_Federation_GetPostResponseVariable struct {
+	Foo *GetPostResponse_Foo
+	P   *Post
 }
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
 type FederationService_Federation_GetPostResponseArgument struct {
-	Foo *GetPostResponse_Foo
-	Id  string
-	P   *Post
+	Id string
+	FederationService_Federation_GetPostResponseVariable
+}
+
+// Federation_GetPostResponse_FooVariable represents variable definitions in "federation.Foo".
+type FederationService_Federation_GetPostResponse_FooVariable struct {
 }
 
 // Federation_GetPostResponse_FooArgument is argument for "federation.Foo" message.
 type FederationService_Federation_GetPostResponse_FooArgument struct {
+	FederationService_Federation_GetPostResponse_FooVariable
 }
 
-// Federation_PostArgument is argument for "federation.Post" message.
-type FederationService_Federation_PostArgument struct {
+// Federation_PostVariable represents variable definitions in "federation.Post".
+type FederationService_Federation_PostVariable struct {
 	Cmp           bool
 	FavoriteValue favorite.FavoriteType
 	Reaction      *Reaction
 	U             *User
 }
 
+// Federation_PostArgument is argument for "federation.Post" message.
+type FederationService_Federation_PostArgument struct {
+	FederationService_Federation_PostVariable
+}
+
+// Federation_ReactionVariable represents variable definitions in "federation.Reaction".
+type FederationService_Federation_ReactionVariable struct {
+	Cmp bool
+}
+
 // Federation_ReactionArgument is argument for "federation.Reaction" message.
 type FederationService_Federation_ReactionArgument struct {
-	Cmp bool
-	V   favorite.FavoriteType
+	V favorite.FavoriteType
+	FederationService_Federation_ReactionVariable
+}
+
+// Federation_UserVariable represents variable definitions in "federation.User".
+type FederationService_Federation_UserVariable struct {
 }
 
 // Federation_UserArgument is argument for "federation.User" message.
 type FederationService_Federation_UserArgument struct {
 	Id   string
 	Name string
+	FederationService_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -455,7 +490,7 @@ func (s *FederationService) resolve_Federation_GetNameResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Foo = value.vars.Foo
+	req.FederationService_Federation_GetNameResponseVariable.Foo = value.vars.Foo
 
 	// create a message value to be returned.
 	ret := &GetNameResponse{}
@@ -629,8 +664,8 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Foo = value.vars.Foo
-	req.P = value.vars.P
+	req.FederationService_Federation_GetPostResponseVariable.Foo = value.vars.Foo
+	req.FederationService_Federation_GetPostResponseVariable.P = value.vars.P
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -917,10 +952,10 @@ func (s *FederationService) resolve_Federation_Post(ctx context.Context, req *Fe
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cmp = value.vars.Cmp
-	req.FavoriteValue = value.vars.FavoriteValue
-	req.Reaction = value.vars.Reaction
-	req.U = value.vars.U
+	req.FederationService_Federation_PostVariable.Cmp = value.vars.Cmp
+	req.FederationService_Federation_PostVariable.FavoriteValue = value.vars.FavoriteValue
+	req.FederationService_Federation_PostVariable.Reaction = value.vars.Reaction
+	req.FederationService_Federation_PostVariable.U = value.vars.U
 
 	// create a message value to be returned.
 	ret := &Post{}
@@ -1067,7 +1102,7 @@ func (s *FederationService) resolve_Federation_Reaction(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cmp = value.vars.Cmp
+	req.FederationService_Federation_ReactionVariable.Cmp = value.vars.Cmp
 
 	// create a message value to be returned.
 	ret := &Reaction{}
@@ -1335,44 +1370,79 @@ func (s *FederationService) logvalue_Federation_UserArgument(v *FederationServic
 	)
 }
 
+// Federation_GetNameResponseVariable represents variable definitions in "federation.GetNameResponse".
+type PrivateService_Federation_GetNameResponseVariable struct {
+	Foo *GetNameResponse_Foo
+}
+
 // Federation_GetNameResponseArgument is argument for "federation.GetNameResponse" message.
 type PrivateService_Federation_GetNameResponseArgument struct {
-	Foo *GetNameResponse_Foo
+	PrivateService_Federation_GetNameResponseVariable
+}
+
+// Federation_GetNameResponse_FooVariable represents variable definitions in "federation.Foo".
+type PrivateService_Federation_GetNameResponse_FooVariable struct {
 }
 
 // Federation_GetNameResponse_FooArgument is argument for "federation.Foo" message.
 type PrivateService_Federation_GetNameResponse_FooArgument struct {
+	PrivateService_Federation_GetNameResponse_FooVariable
+}
+
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type PrivateService_Federation_GetPostResponseVariable struct {
+	Foo *GetPostResponse_Foo
+	P   *Post
 }
 
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
 type PrivateService_Federation_GetPostResponseArgument struct {
-	Foo *GetPostResponse_Foo
-	Id  string
-	P   *Post
+	Id string
+	PrivateService_Federation_GetPostResponseVariable
+}
+
+// Federation_GetPostResponse_FooVariable represents variable definitions in "federation.Foo".
+type PrivateService_Federation_GetPostResponse_FooVariable struct {
 }
 
 // Federation_GetPostResponse_FooArgument is argument for "federation.Foo" message.
 type PrivateService_Federation_GetPostResponse_FooArgument struct {
+	PrivateService_Federation_GetPostResponse_FooVariable
 }
 
-// Federation_PostArgument is argument for "federation.Post" message.
-type PrivateService_Federation_PostArgument struct {
+// Federation_PostVariable represents variable definitions in "federation.Post".
+type PrivateService_Federation_PostVariable struct {
 	Cmp           bool
 	FavoriteValue favorite.FavoriteType
 	Reaction      *Reaction
 	U             *User
 }
 
+// Federation_PostArgument is argument for "federation.Post" message.
+type PrivateService_Federation_PostArgument struct {
+	PrivateService_Federation_PostVariable
+}
+
+// Federation_ReactionVariable represents variable definitions in "federation.Reaction".
+type PrivateService_Federation_ReactionVariable struct {
+	Cmp bool
+}
+
 // Federation_ReactionArgument is argument for "federation.Reaction" message.
 type PrivateService_Federation_ReactionArgument struct {
-	Cmp bool
-	V   favorite.FavoriteType
+	V favorite.FavoriteType
+	PrivateService_Federation_ReactionVariable
+}
+
+// Federation_UserVariable represents variable definitions in "federation.User".
+type PrivateService_Federation_UserVariable struct {
 }
 
 // Federation_UserArgument is argument for "federation.User" message.
 type PrivateService_Federation_UserArgument struct {
 	Id   string
 	Name string
+	PrivateService_Federation_UserVariable
 }
 
 // PrivateServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -1881,7 +1951,7 @@ func (s *PrivateService) resolve_Federation_GetNameResponse(ctx context.Context,
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Foo = value.vars.Foo
+	req.PrivateService_Federation_GetNameResponseVariable.Foo = value.vars.Foo
 
 	// create a message value to be returned.
 	ret := &GetNameResponse{}
@@ -2055,8 +2125,8 @@ func (s *PrivateService) resolve_Federation_GetPostResponse(ctx context.Context,
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Foo = value.vars.Foo
-	req.P = value.vars.P
+	req.PrivateService_Federation_GetPostResponseVariable.Foo = value.vars.Foo
+	req.PrivateService_Federation_GetPostResponseVariable.P = value.vars.P
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -2343,10 +2413,10 @@ func (s *PrivateService) resolve_Federation_Post(ctx context.Context, req *Priva
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cmp = value.vars.Cmp
-	req.FavoriteValue = value.vars.FavoriteValue
-	req.Reaction = value.vars.Reaction
-	req.U = value.vars.U
+	req.PrivateService_Federation_PostVariable.Cmp = value.vars.Cmp
+	req.PrivateService_Federation_PostVariable.FavoriteValue = value.vars.FavoriteValue
+	req.PrivateService_Federation_PostVariable.Reaction = value.vars.Reaction
+	req.PrivateService_Federation_PostVariable.U = value.vars.U
 
 	// create a message value to be returned.
 	ret := &Post{}
@@ -2493,7 +2563,7 @@ func (s *PrivateService) resolve_Federation_Reaction(ctx context.Context, req *P
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cmp = value.vars.Cmp
+	req.PrivateService_Federation_ReactionVariable.Cmp = value.vars.Cmp
 
 	// create a message value to be returned.
 	ret := &Reaction{}
@@ -2761,15 +2831,25 @@ func (s *PrivateService) logvalue_Federation_UserArgument(v *PrivateService_Fede
 	)
 }
 
+// Federation_GetStatusResponseVariable represents variable definitions in "federation.GetStatusResponse".
+type DebugService_Federation_GetStatusResponseVariable struct {
+	U *User
+}
+
 // Federation_GetStatusResponseArgument is argument for "federation.GetStatusResponse" message.
 type DebugService_Federation_GetStatusResponseArgument struct {
-	U *User
+	DebugService_Federation_GetStatusResponseVariable
+}
+
+// Federation_UserVariable represents variable definitions in "federation.User".
+type DebugService_Federation_UserVariable struct {
 }
 
 // Federation_UserArgument is argument for "federation.User" message.
 type DebugService_Federation_UserArgument struct {
 	Id   string
 	Name string
+	DebugService_Federation_UserVariable
 }
 
 // DebugServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -2978,7 +3058,7 @@ func (s *DebugService) resolve_Federation_GetStatusResponse(ctx context.Context,
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.U = value.vars.U
+	req.DebugService_Federation_GetStatusResponseVariable.U = value.vars.U
 
 	// create a message value to be returned.
 	ret := &GetStatusResponse{}

--- a/_examples/11_multi_service/federation/other_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/other_grpc_federation.pb.go
@@ -24,10 +24,15 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Federation_GetResponseVariable represents variable definitions in "federation.GetResponse".
+type OtherService_Federation_GetResponseVariable struct {
+	P *Post
+}
+
 // Federation_GetResponseArgument is argument for "federation.GetResponse" message.
 type OtherService_Federation_GetResponseArgument struct {
 	Id string
-	P  *Post
+	OtherService_Federation_GetResponseVariable
 }
 
 // Federation_GetResponse_PostArgument is custom resolver's argument for "post" field of "federation.GetResponse" message.
@@ -35,24 +40,39 @@ type OtherService_Federation_GetResponse_PostArgument struct {
 	*OtherService_Federation_GetResponseArgument
 }
 
-// Federation_PostArgument is argument for "federation.Post" message.
-type OtherService_Federation_PostArgument struct {
+// Federation_PostVariable represents variable definitions in "federation.Post".
+type OtherService_Federation_PostVariable struct {
 	Cmp           bool
 	FavoriteValue favorite.FavoriteType
 	Reaction      *Reaction
 	U             *User
 }
 
+// Federation_PostArgument is argument for "federation.Post" message.
+type OtherService_Federation_PostArgument struct {
+	OtherService_Federation_PostVariable
+}
+
+// Federation_ReactionVariable represents variable definitions in "federation.Reaction".
+type OtherService_Federation_ReactionVariable struct {
+	Cmp bool
+}
+
 // Federation_ReactionArgument is argument for "federation.Reaction" message.
 type OtherService_Federation_ReactionArgument struct {
-	Cmp bool
-	V   favorite.FavoriteType
+	V favorite.FavoriteType
+	OtherService_Federation_ReactionVariable
+}
+
+// Federation_UserVariable represents variable definitions in "federation.User".
+type OtherService_Federation_UserVariable struct {
 }
 
 // Federation_UserArgument is argument for "federation.User" message.
 type OtherService_Federation_UserArgument struct {
 	Id   string
 	Name string
+	OtherService_Federation_UserVariable
 }
 
 // OtherServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -258,7 +278,7 @@ func (s *OtherService) resolve_Federation_GetResponse(ctx context.Context, req *
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.P = value.vars.P
+	req.OtherService_Federation_GetResponseVariable.P = value.vars.P
 
 	// create a message value to be returned.
 	ret := &GetResponse{}
@@ -478,10 +498,10 @@ func (s *OtherService) resolve_Federation_Post(ctx context.Context, req *OtherSe
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cmp = value.vars.Cmp
-	req.FavoriteValue = value.vars.FavoriteValue
-	req.Reaction = value.vars.Reaction
-	req.U = value.vars.U
+	req.OtherService_Federation_PostVariable.Cmp = value.vars.Cmp
+	req.OtherService_Federation_PostVariable.FavoriteValue = value.vars.FavoriteValue
+	req.OtherService_Federation_PostVariable.Reaction = value.vars.Reaction
+	req.OtherService_Federation_PostVariable.U = value.vars.U
 
 	// create a message value to be returned.
 	ret := &Post{}
@@ -626,7 +646,7 @@ func (s *OtherService) resolve_Federation_Reaction(ctx context.Context, req *Oth
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cmp = value.vars.Cmp
+	req.OtherService_Federation_ReactionVariable.Cmp = value.vars.Cmp
 
 	// create a message value to be returned.
 	ret := &Reaction{}

--- a/_examples/12_validation/federation/federation_grpc_federation.pb.go
+++ b/_examples/12_validation/federation/federation_grpc_federation.pb.go
@@ -22,27 +22,47 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_CustomHandlerMessageVariable represents variable definitions in "org.federation.CustomHandlerMessage".
+type FederationService_Org_Federation_CustomHandlerMessageVariable struct {
+}
+
 // Org_Federation_CustomHandlerMessageArgument is argument for "org.federation.CustomHandlerMessage" message.
 type FederationService_Org_Federation_CustomHandlerMessageArgument struct {
 	Arg string
+	FederationService_Org_Federation_CustomHandlerMessageVariable
+}
+
+// Org_Federation_CustomMessageVariable represents variable definitions in "org.federation.CustomMessage".
+type FederationService_Org_Federation_CustomMessageVariable struct {
 }
 
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
 type FederationService_Org_Federation_CustomMessageArgument struct {
 	Message string
+	FederationService_Org_Federation_CustomMessageVariable
 }
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	Condition           bool
-	Id                  string
 	Post                *Post
 	XDef4ErrDetail0Msg0 *CustomMessage
 	XDef4ErrDetail0Msg1 *CustomMessage
 }
 
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
+}
+
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
 type FederationService_Org_Federation_PostArgument struct {
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -993,10 +1013,10 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Condition = value.vars.Condition
-	req.Post = value.vars.Post
-	req.XDef4ErrDetail0Msg0 = value.vars.XDef4ErrDetail0Msg0
-	req.XDef4ErrDetail0Msg1 = value.vars.XDef4ErrDetail0Msg1
+	req.FederationService_Org_Federation_GetPostResponseVariable.Condition = value.vars.Condition
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.XDef4ErrDetail0Msg0 = value.vars.XDef4ErrDetail0Msg0
+	req.FederationService_Org_Federation_GetPostResponseVariable.XDef4ErrDetail0Msg1 = value.vars.XDef4ErrDetail0Msg1
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -25,18 +25,22 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostsResponseArgument is argument for "org.federation.GetPostsResponse" message.
-type FederationService_Org_Federation_GetPostsResponseArgument struct {
-	Ids   []string
+// Org_Federation_GetPostsResponseVariable represents variable definitions in "org.federation.GetPostsResponse".
+type FederationService_Org_Federation_GetPostsResponseVariable struct {
 	Posts *Posts
 }
 
-// Org_Federation_PostsArgument is argument for "org.federation.Posts" message.
-type FederationService_Org_Federation_PostsArgument struct {
+// Org_Federation_GetPostsResponseArgument is argument for "org.federation.GetPostsResponse" message.
+type FederationService_Org_Federation_GetPostsResponseArgument struct {
+	Ids []string
+	FederationService_Org_Federation_GetPostsResponseVariable
+}
+
+// Org_Federation_PostsVariable represents variable definitions in "org.federation.Posts".
+type FederationService_Org_Federation_PostsVariable struct {
 	Ids               []string
 	ItemTypes         []Item_ItemType
 	Items             []*Posts_PostItem
-	PostIds           []string
 	Posts             []*post.Post
 	Res               *post.GetPostsResponse
 	SelectedItemTypes []Item_ItemType
@@ -44,16 +48,32 @@ type FederationService_Org_Federation_PostsArgument struct {
 	Users             []*User
 }
 
+// Org_Federation_PostsArgument is argument for "org.federation.Posts" message.
+type FederationService_Org_Federation_PostsArgument struct {
+	PostIds []string
+	FederationService_Org_Federation_PostsVariable
+}
+
+// Org_Federation_Posts_PostItemVariable represents variable definitions in "org.federation.PostItem".
+type FederationService_Org_Federation_Posts_PostItemVariable struct {
+}
+
 // Org_Federation_Posts_PostItemArgument is argument for "org.federation.PostItem" message.
 type FederationService_Org_Federation_Posts_PostItemArgument struct {
 	Id string
+	FederationService_Org_Federation_Posts_PostItemVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+	Res  *user.GetUserResponse
+	User *user.User
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
-	Res    *user.GetUserResponse
-	User   *user.User
 	UserId string
+	FederationService_Org_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -288,7 +308,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Posts = value.vars.Posts
+	req.FederationService_Org_Federation_GetPostsResponseVariable.Posts = value.vars.Posts
 
 	// create a message value to be returned.
 	ret := &GetPostsResponse{}
@@ -728,14 +748,14 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Ids = value.vars.Ids
-	req.ItemTypes = value.vars.ItemTypes
-	req.Items = value.vars.Items
-	req.Posts = value.vars.Posts
-	req.Res = value.vars.Res
-	req.SelectedItemTypes = value.vars.SelectedItemTypes
-	req.SourceItemTypes = value.vars.SourceItemTypes
-	req.Users = value.vars.Users
+	req.FederationService_Org_Federation_PostsVariable.Ids = value.vars.Ids
+	req.FederationService_Org_Federation_PostsVariable.ItemTypes = value.vars.ItemTypes
+	req.FederationService_Org_Federation_PostsVariable.Items = value.vars.Items
+	req.FederationService_Org_Federation_PostsVariable.Posts = value.vars.Posts
+	req.FederationService_Org_Federation_PostsVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostsVariable.SelectedItemTypes = value.vars.SelectedItemTypes
+	req.FederationService_Org_Federation_PostsVariable.SourceItemTypes = value.vars.SourceItemTypes
+	req.FederationService_Org_Federation_PostsVariable.Users = value.vars.Users
 
 	// create a message value to be returned.
 	ret := &Posts{}
@@ -961,8 +981,8 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.User = value.vars.User
+	req.FederationService_Org_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_UserVariable.User = value.vars.User
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -24,15 +24,19 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id   string
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	Post *Post
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
-	Id    string
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Post  *post.Post
 	Posts []*post.Post
 	Res   *post.GetPostResponse
@@ -40,9 +44,20 @@ type FederationService_Org_Federation_PostArgument struct {
 	Users []*User
 }
 
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+}
+
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	UserId string
+	FederationService_Org_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -261,7 +276,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -567,11 +582,11 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.Posts = value.vars.Posts
-	req.Res = value.vars.Res
-	req.User = value.vars.User
-	req.Users = value.vars.Users
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Posts = value.vars.Posts
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.User = value.vars.User
+	req.FederationService_Org_Federation_PostVariable.Users = value.vars.Users
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
@@ -24,14 +24,19 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Example_Regexp_ExampleArgument is argument for "example.regexp.Example" message.
-type FederationService_Example_Regexp_ExampleArgument struct {
-	V     int64
-	Value int64
+// Example_Regexp_ExampleVariable represents variable definitions in "example.regexp.Example".
+type FederationService_Example_Regexp_ExampleVariable struct {
+	V int64
 }
 
-// Org_Federation_ExampleResponseArgument is argument for "org.federation.ExampleResponse" message.
-type FederationService_Org_Federation_ExampleResponseArgument struct {
+// Example_Regexp_ExampleArgument is argument for "example.regexp.Example" message.
+type FederationService_Example_Regexp_ExampleArgument struct {
+	Value int64
+	FederationService_Example_Regexp_ExampleVariable
+}
+
+// Org_Federation_ExampleResponseVariable represents variable definitions in "org.federation.ExampleResponse".
+type FederationService_Org_Federation_ExampleResponseVariable struct {
 	Exp    *pluginpb.Example
 	ExpMsg *pluginpb.Example
 	Exps   []*pluginpb.Example
@@ -39,12 +44,22 @@ type FederationService_Org_Federation_ExampleResponseArgument struct {
 	V      []*pluginpb.Example
 }
 
-// Org_Federation_IsMatchResponseArgument is argument for "org.federation.IsMatchResponse" message.
-type FederationService_Org_Federation_IsMatchResponseArgument struct {
-	Expr    string
+// Org_Federation_ExampleResponseArgument is argument for "org.federation.ExampleResponse" message.
+type FederationService_Org_Federation_ExampleResponseArgument struct {
+	FederationService_Org_Federation_ExampleResponseVariable
+}
+
+// Org_Federation_IsMatchResponseVariable represents variable definitions in "org.federation.IsMatchResponse".
+type FederationService_Org_Federation_IsMatchResponseVariable struct {
 	Matched bool
 	Re      *pluginpb.Regexp
-	Target  string
+}
+
+// Org_Federation_IsMatchResponseArgument is argument for "org.federation.IsMatchResponse" message.
+type FederationService_Org_Federation_IsMatchResponseArgument struct {
+	Expr   string
+	Target string
+	FederationService_Org_Federation_IsMatchResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -345,7 +360,7 @@ func (s *FederationService) resolve_Example_Regexp_Example(ctx context.Context, 
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.V = value.vars.V
+	req.FederationService_Example_Regexp_ExampleVariable.V = value.vars.V
 
 	// create a message value to be returned.
 	ret := &pluginpb.Example{}
@@ -550,11 +565,11 @@ func (s *FederationService) resolve_Org_Federation_ExampleResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Exp = value.vars.Exp
-	req.ExpMsg = value.vars.ExpMsg
-	req.Exps = value.vars.Exps
-	req.Str = value.vars.Str
-	req.V = value.vars.V
+	req.FederationService_Org_Federation_ExampleResponseVariable.Exp = value.vars.Exp
+	req.FederationService_Org_Federation_ExampleResponseVariable.ExpMsg = value.vars.ExpMsg
+	req.FederationService_Org_Federation_ExampleResponseVariable.Exps = value.vars.Exps
+	req.FederationService_Org_Federation_ExampleResponseVariable.Str = value.vars.Str
+	req.FederationService_Org_Federation_ExampleResponseVariable.V = value.vars.V
 
 	// create a message value to be returned.
 	ret := &ExampleResponse{}
@@ -667,8 +682,8 @@ func (s *FederationService) resolve_Org_Federation_IsMatchResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Matched = value.vars.Matched
-	req.Re = value.vars.Re
+	req.FederationService_Org_Federation_IsMatchResponseVariable.Matched = value.vars.Matched
+	req.FederationService_Org_Federation_IsMatchResponseVariable.Re = value.vars.Re
 
 	// create a message value to be returned.
 	ret := &IsMatchResponse{}

--- a/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
@@ -22,9 +22,14 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
+}
+
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
 type FederationService_Org_Federation_GetResponseArgument struct {
 	Id int64
+	FederationService_Org_Federation_GetResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -25,35 +25,61 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_CustomMessageVariable represents variable definitions in "org.federation.CustomMessage".
+type FederationService_Org_Federation_CustomMessageVariable struct {
+}
+
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
 type FederationService_Org_Federation_CustomMessageArgument struct {
 	ErrorInfo *grpcfedcel.Error
+	FederationService_Org_Federation_CustomMessageVariable
+}
+
+// Org_Federation_GetPost2ResponseVariable represents variable definitions in "org.federation.GetPost2Response".
+type FederationService_Org_Federation_GetPost2ResponseVariable struct {
+	Code code.Code
 }
 
 // Org_Federation_GetPost2ResponseArgument is argument for "org.federation.GetPost2Response" message.
 type FederationService_Org_Federation_GetPost2ResponseArgument struct {
-	Code code.Code
-	Id   string
+	Id string
+	FederationService_Org_Federation_GetPost2ResponseVariable
+}
+
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
+	Post *Post
 }
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
 type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id   string
-	Post *Post
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_LocalizedMessageVariable represents variable definitions in "org.federation.LocalizedMessage".
+type FederationService_Org_Federation_LocalizedMessageVariable struct {
 }
 
 // Org_Federation_LocalizedMessageArgument is argument for "org.federation.LocalizedMessage" message.
 type FederationService_Org_Federation_LocalizedMessageArgument struct {
 	Value string
+	FederationService_Org_Federation_LocalizedMessageVariable
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Id                  string
 	LocalizedMsg        *LocalizedMessage
 	Post                *post.Post
 	Res                 *post.GetPostResponse
 	XDef0ErrDetail0Msg0 *CustomMessage
+}
+
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -443,7 +469,7 @@ func (s *FederationService) resolve_Org_Federation_GetPost2Response(ctx context.
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Code = value.vars.Code
+	req.FederationService_Org_Federation_GetPost2ResponseVariable.Code = value.vars.Code
 
 	// create a message value to be returned.
 	ret := &GetPost2Response{}
@@ -512,7 +538,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -1018,11 +1044,11 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Id = value.vars.Id
-	req.LocalizedMsg = value.vars.LocalizedMsg
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.XDef0ErrDetail0Msg0 = value.vars.XDef0ErrDetail0Msg0
+	req.FederationService_Org_Federation_PostVariable.Id = value.vars.Id
+	req.FederationService_Org_Federation_PostVariable.LocalizedMsg = value.vars.LocalizedMsg
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.XDef0ErrDetail0Msg0 = value.vars.XDef0ErrDetail0Msg0
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/_examples/18_load/federation/federation_grpc_federation.pb.go
+++ b/_examples/18_load/federation/federation_grpc_federation.pb.go
@@ -22,10 +22,15 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	IdFromMetadata string
 	IdFromPlugin   string
+}
+
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
+	FederationService_Org_Federation_GetResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -283,8 +288,8 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.IdFromMetadata = value.vars.IdFromMetadata
-	req.IdFromPlugin = value.vars.IdFromPlugin
+	req.FederationService_Org_Federation_GetResponseVariable.IdFromMetadata = value.vars.IdFromMetadata
+	req.FederationService_Org_Federation_GetResponseVariable.IdFromPlugin = value.vars.IdFromPlugin
 
 	// create a message value to be returned.
 	ret := &GetResponse{}

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -24,14 +24,24 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type FederationService_Federation_GetPostResponseVariable struct {
+}
+
 // Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
 type FederationService_Federation_GetPostResponseArgument struct {
 	Id string
+	FederationService_Federation_GetPostResponseVariable
+}
+
+// Federation_PostVariable represents variable definitions in "federation.Post".
+type FederationService_Federation_PostVariable struct {
 }
 
 // Federation_PostArgument is argument for "federation.Post" message.
 type FederationService_Federation_PostArgument struct {
 	Id string
+	FederationService_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.

--- a/_examples/20_callopt/federation/federation_grpc_federation.pb.go
+++ b/_examples/20_callopt/federation/federation_grpc_federation.pb.go
@@ -24,14 +24,19 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
-type FederationService_Federation_GetPostResponseArgument struct {
+// Federation_GetPostResponseVariable represents variable definitions in "federation.GetPostResponse".
+type FederationService_Federation_GetPostResponseVariable struct {
 	Hdr     map[string][]string
 	HdrKeys []string
-	Id      string
 	Res     *post.GetPostResponse
 	Tlr     map[string][]string
 	TlrKeys []string
+}
+
+// Federation_GetPostResponseArgument is argument for "federation.GetPostResponse" message.
+type FederationService_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Federation_GetPostResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -472,11 +477,11 @@ func (s *FederationService) resolve_Federation_GetPostResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Hdr = value.vars.Hdr
-	req.HdrKeys = value.vars.HdrKeys
-	req.Res = value.vars.Res
-	req.Tlr = value.vars.Tlr
-	req.TlrKeys = value.vars.TlrKeys
+	req.FederationService_Federation_GetPostResponseVariable.Hdr = value.vars.Hdr
+	req.FederationService_Federation_GetPostResponseVariable.HdrKeys = value.vars.HdrKeys
+	req.FederationService_Federation_GetPostResponseVariable.Res = value.vars.Res
+	req.FederationService_Federation_GetPostResponseVariable.Tlr = value.vars.Tlr
+	req.FederationService_Federation_GetPostResponseVariable.TlrKeys = value.vars.TlrKeys
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}

--- a/_examples/21_wasm_net/federation/federation_grpc_federation.pb.go
+++ b/_examples/21_wasm_net/federation/federation_grpc_federation.pb.go
@@ -22,13 +22,18 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	Body string
 	File string
 	Foo  string
+}
+
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
 	Path string
 	Url  string
+	FederationService_Org_Federation_GetResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -341,9 +346,9 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Body = value.vars.Body
-	req.File = value.vars.File
-	req.Foo = value.vars.Foo
+	req.FederationService_Org_Federation_GetResponseVariable.Body = value.vars.Body
+	req.FederationService_Org_Federation_GetResponseVariable.File = value.vars.File
+	req.FederationService_Org_Federation_GetResponseVariable.Foo = value.vars.Foo
 
 	// create a message value to be returned.
 	ret := &GetResponse{}

--- a/generator/templates/server.go.tmpl
+++ b/generator/templates/server.go.tmpl
@@ -55,6 +55,15 @@ var {{ .Name }}_attrMap = grpcfed.EnumAttributeMap[{{ .Name }}]{
 
 {{- range $types }}
 
+{{- if .VariableType }}
+// {{ .VariableType.Desc }}.
+type {{ $serviceName }}_{{ .VariableType.Name }} struct {
+	{{- range .VariableType.Fields }}
+	{{ .Name }} {{ .Type }}
+	{{- end }}
+}
+{{- end }}
+
 // {{ .Desc }}.
 type {{ $serviceName }}_{{ .Name }} struct {
 	{{- range .Fields }}
@@ -63,6 +72,9 @@ type {{ $serviceName }}_{{ .Name }} struct {
 	{{- else }}
 	*{{ $serviceName }}_{{ .Type }}
 	{{- end }}
+	{{- end }}
+	{{- if .VariableType }}
+	{{ $serviceName }}_{{ .VariableType.Name }}
 	{{- end }}
 }
 

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -24,21 +24,31 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
+	Post *Post
+}
+
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
 type FederationService_Org_Federation_GetPostResponseArgument struct {
-	A    *GetPostRequest_ConditionA
-	B    *GetPostRequest_ConditionB
-	Id   string
-	Post *Post
+	A  *GetPostRequest_ConditionA
+	B  *GetPostRequest_ConditionB
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
+	Post *post.Post
+	Res  *post.GetPostResponse
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
 type FederationService_Org_Federation_PostArgument struct {
-	A    *GetPostRequest_ConditionA
-	B    *GetPostRequest_ConditionB
-	Id   string
-	Post *post.Post
-	Res  *post.GetPostResponse
+	A  *GetPostRequest_ConditionA
+	B  *GetPostRequest_ConditionB
+	Id string
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -292,7 +302,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -458,8 +468,8 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/generator/testdata/expected_async.go
+++ b/generator/testdata/expected_async.go
@@ -22,50 +22,95 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_AAVariable represents variable definitions in "org.federation.AA".
+type FederationService_Org_Federation_AAVariable struct {
+}
+
 // Org_Federation_AAArgument is argument for "org.federation.AA" message.
 type FederationService_Org_Federation_AAArgument struct {
+	FederationService_Org_Federation_AAVariable
+}
+
+// Org_Federation_AVariable represents variable definitions in "org.federation.A".
+type FederationService_Org_Federation_AVariable struct {
 }
 
 // Org_Federation_AArgument is argument for "org.federation.A" message.
 type FederationService_Org_Federation_AArgument struct {
+	FederationService_Org_Federation_AVariable
+}
+
+// Org_Federation_ABVariable represents variable definitions in "org.federation.AB".
+type FederationService_Org_Federation_ABVariable struct {
 }
 
 // Org_Federation_ABArgument is argument for "org.federation.AB" message.
 type FederationService_Org_Federation_ABArgument struct {
+	FederationService_Org_Federation_ABVariable
+}
+
+// Org_Federation_BVariable represents variable definitions in "org.federation.B".
+type FederationService_Org_Federation_BVariable struct {
 }
 
 // Org_Federation_BArgument is argument for "org.federation.B" message.
 type FederationService_Org_Federation_BArgument struct {
+	FederationService_Org_Federation_BVariable
+}
+
+// Org_Federation_CVariable represents variable definitions in "org.federation.C".
+type FederationService_Org_Federation_CVariable struct {
 }
 
 // Org_Federation_CArgument is argument for "org.federation.C" message.
 type FederationService_Org_Federation_CArgument struct {
 	A string
+	FederationService_Org_Federation_CVariable
+}
+
+// Org_Federation_DVariable represents variable definitions in "org.federation.D".
+type FederationService_Org_Federation_DVariable struct {
 }
 
 // Org_Federation_DArgument is argument for "org.federation.D" message.
 type FederationService_Org_Federation_DArgument struct {
 	B string
+	FederationService_Org_Federation_DVariable
+}
+
+// Org_Federation_EVariable represents variable definitions in "org.federation.E".
+type FederationService_Org_Federation_EVariable struct {
 }
 
 // Org_Federation_EArgument is argument for "org.federation.E" message.
 type FederationService_Org_Federation_EArgument struct {
 	C string
 	D string
+	FederationService_Org_Federation_EVariable
+}
+
+// Org_Federation_FVariable represents variable definitions in "org.federation.F".
+type FederationService_Org_Federation_FVariable struct {
 }
 
 // Org_Federation_FArgument is argument for "org.federation.F" message.
 type FederationService_Org_Federation_FArgument struct {
 	C string
 	D string
+	FederationService_Org_Federation_FVariable
+}
+
+// Org_Federation_GVariable represents variable definitions in "org.federation.G".
+type FederationService_Org_Federation_GVariable struct {
 }
 
 // Org_Federation_GArgument is argument for "org.federation.G" message.
 type FederationService_Org_Federation_GArgument struct {
+	FederationService_Org_Federation_GVariable
 }
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	A *A
 	B *B
 	C *C
@@ -78,20 +123,40 @@ type FederationService_Org_Federation_GetResponseArgument struct {
 	J *J
 }
 
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
+	FederationService_Org_Federation_GetResponseVariable
+}
+
+// Org_Federation_HVariable represents variable definitions in "org.federation.H".
+type FederationService_Org_Federation_HVariable struct {
+}
+
 // Org_Federation_HArgument is argument for "org.federation.H" message.
 type FederationService_Org_Federation_HArgument struct {
 	E string
 	F string
 	G string
+	FederationService_Org_Federation_HVariable
+}
+
+// Org_Federation_IVariable represents variable definitions in "org.federation.I".
+type FederationService_Org_Federation_IVariable struct {
 }
 
 // Org_Federation_IArgument is argument for "org.federation.I" message.
 type FederationService_Org_Federation_IArgument struct {
+	FederationService_Org_Federation_IVariable
+}
+
+// Org_Federation_JVariable represents variable definitions in "org.federation.J".
+type FederationService_Org_Federation_JVariable struct {
 }
 
 // Org_Federation_JArgument is argument for "org.federation.J" message.
 type FederationService_Org_Federation_JArgument struct {
 	I string
+	FederationService_Org_Federation_JVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -1203,16 +1268,16 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.A = value.vars.A
-	req.B = value.vars.B
-	req.C = value.vars.C
-	req.D = value.vars.D
-	req.E = value.vars.E
-	req.F = value.vars.F
-	req.G = value.vars.G
-	req.H = value.vars.H
-	req.I = value.vars.I
-	req.J = value.vars.J
+	req.FederationService_Org_Federation_GetResponseVariable.A = value.vars.A
+	req.FederationService_Org_Federation_GetResponseVariable.B = value.vars.B
+	req.FederationService_Org_Federation_GetResponseVariable.C = value.vars.C
+	req.FederationService_Org_Federation_GetResponseVariable.D = value.vars.D
+	req.FederationService_Org_Federation_GetResponseVariable.E = value.vars.E
+	req.FederationService_Org_Federation_GetResponseVariable.F = value.vars.F
+	req.FederationService_Org_Federation_GetResponseVariable.G = value.vars.G
+	req.FederationService_Org_Federation_GetResponseVariable.H = value.vars.H
+	req.FederationService_Org_Federation_GetResponseVariable.I = value.vars.I
+	req.FederationService_Org_Federation_GetResponseVariable.J = value.vars.J
 
 	// create a message value to be returned.
 	ret := &GetResponse{}

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -24,23 +24,38 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id    string
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	XDef0 *Post
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
-	Id    string
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Res   *post.GetPostResponse
 	XDef1 *post.Post
 	XDef2 *User
 }
 
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+}
+
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	UserId string
+	FederationService_Org_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -261,7 +276,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.XDef0 = value.vars.XDef0
+	req.FederationService_Org_Federation_GetPostResponseVariable.XDef0 = value.vars.XDef0
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -428,9 +443,9 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.XDef1 = value.vars.XDef1
-	req.XDef2 = value.vars.XDef2
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.XDef1 = value.vars.XDef1
+	req.FederationService_Org_Federation_PostVariable.XDef2 = value.vars.XDef2
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -24,15 +24,19 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id   string
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	Post *Post
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
-	Id    string
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Post  *post.Post
 	Posts []*post.Post
 	Res   *post.GetPostResponse
@@ -40,9 +44,20 @@ type FederationService_Org_Federation_PostArgument struct {
 	Users []*User
 }
 
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+}
+
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	UserId string
+	FederationService_Org_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -262,7 +277,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -568,11 +583,11 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.Posts = value.vars.Posts
-	req.Res = value.vars.Res
-	req.User = value.vars.User
-	req.Users = value.vars.Users
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Posts = value.vars.Posts
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.User = value.vars.User
+	req.FederationService_Org_Federation_PostVariable.Users = value.vars.Users
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -25,28 +25,43 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_CreatePostVariable represents variable definitions in "org.federation.CreatePost".
+type FederationService_Org_Federation_CreatePostVariable struct {
+}
+
 // Org_Federation_CreatePostArgument is argument for "org.federation.CreatePost" message.
 type FederationService_Org_Federation_CreatePostArgument struct {
 	Content string
 	Title   string
 	Type    PostType
 	UserId  string
+	FederationService_Org_Federation_CreatePostVariable
+}
+
+// Org_Federation_CreatePostResponseVariable represents variable definitions in "org.federation.CreatePostResponse".
+type FederationService_Org_Federation_CreatePostResponseVariable struct {
+	Cp  *CreatePost
+	P   *post.Post
+	Res *post.CreatePostResponse
 }
 
 // Org_Federation_CreatePostResponseArgument is argument for "org.federation.CreatePostResponse" message.
 type FederationService_Org_Federation_CreatePostResponseArgument struct {
 	Content string
-	Cp      *CreatePost
-	P       *post.Post
-	Res     *post.CreatePostResponse
 	Title   string
 	Type    PostType
 	UserId  string
+	FederationService_Org_Federation_CreatePostResponseVariable
+}
+
+// Org_Federation_UpdatePostResponseVariable represents variable definitions in "org.federation.UpdatePostResponse".
+type FederationService_Org_Federation_UpdatePostResponseVariable struct {
 }
 
 // Org_Federation_UpdatePostResponseArgument is argument for "org.federation.UpdatePostResponse" message.
 type FederationService_Org_Federation_UpdatePostResponseArgument struct {
 	Id string
+	FederationService_Org_Federation_UpdatePostResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -518,9 +533,9 @@ func (s *FederationService) resolve_Org_Federation_CreatePostResponse(ctx contex
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Cp = value.vars.Cp
-	req.P = value.vars.P
-	req.Res = value.vars.Res
+	req.FederationService_Org_Federation_CreatePostResponseVariable.Cp = value.vars.Cp
+	req.FederationService_Org_Federation_CreatePostResponseVariable.P = value.vars.P
+	req.FederationService_Org_Federation_CreatePostResponseVariable.Res = value.vars.Res
 
 	// create a message value to be returned.
 	ret := &CreatePostResponse{}

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -25,18 +25,28 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
+	Post *Post
+}
+
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
 type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id   string
-	Post *Post
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
+	Post *post.Post
+	Res  *post.GetPostResponse
+	User *User
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
 type FederationService_Org_Federation_PostArgument struct {
-	Id   string
-	Post *post.Post
-	Res  *post.GetPostResponse
-	User *User
+	Id string
+	FederationService_Org_Federation_PostVariable
 }
 
 // Org_Federation_Post_UserArgument is custom resolver's argument for "user" field of "org.federation.Post" message.
@@ -44,14 +54,19 @@ type FederationService_Org_Federation_Post_UserArgument struct {
 	*FederationService_Org_Federation_PostArgument
 }
 
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+	Res *user.GetUserResponse
+	U   *user.User
+}
+
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	Content string
 	Id      string
-	Res     *user.GetUserResponse
 	Title   string
-	U       *user.User
 	UserId  string
+	FederationService_Org_Federation_UserVariable
 }
 
 // Org_Federation_User_NameArgument is custom resolver's argument for "name" field of "org.federation.User" message.
@@ -328,7 +343,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -488,9 +503,9 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.User = value.vars.User
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.User = value.vars.User
 
 	// create a message value to be returned.
 	ret := &Post{}
@@ -603,8 +618,8 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.U = value.vars.U
+	req.FederationService_Org_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_UserVariable.U = value.vars.U
 
 	// create a message value to be returned.
 	// `custom_resolver = true` in "grpc.federation.message" option.

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -24,29 +24,50 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_CustomMessageVariable represents variable definitions in "org.federation.CustomMessage".
+type FederationService_Org_Federation_CustomMessageVariable struct {
+}
+
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
 type FederationService_Org_Federation_CustomMessageArgument struct {
 	Msg string
+	FederationService_Org_Federation_CustomMessageVariable
+}
+
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
+	Post *Post
 }
 
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
 type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id   string
-	Post *Post
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_LocalizedMessageVariable represents variable definitions in "org.federation.LocalizedMessage".
+type FederationService_Org_Federation_LocalizedMessageVariable struct {
 }
 
 // Org_Federation_LocalizedMessageArgument is argument for "org.federation.LocalizedMessage" message.
 type FederationService_Org_Federation_LocalizedMessageArgument struct {
 	Value string
+	FederationService_Org_Federation_LocalizedMessageVariable
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	Id                  string
 	LocalizedMsg        *LocalizedMessage
 	Post                *post.Post
 	Res                 *post.GetPostResponse
 	XDef0ErrDetail0Msg0 *CustomMessage
+}
+
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -305,7 +326,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -761,11 +782,11 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Id = value.vars.Id
-	req.LocalizedMsg = value.vars.LocalizedMsg
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.XDef0ErrDetail0Msg0 = value.vars.XDef0ErrDetail0Msg0
+	req.FederationService_Org_Federation_PostVariable.Id = value.vars.Id
+	req.FederationService_Org_Federation_PostVariable.LocalizedMsg = value.vars.LocalizedMsg
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.XDef0ErrDetail0Msg0 = value.vars.XDef0ErrDetail0Msg0
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -25,17 +25,21 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetPostsResponseArgument is argument for "org.federation.GetPostsResponse" message.
-type FederationService_Org_Federation_GetPostsResponseArgument struct {
-	Ids   []string
+// Org_Federation_GetPostsResponseVariable represents variable definitions in "org.federation.GetPostsResponse".
+type FederationService_Org_Federation_GetPostsResponseVariable struct {
 	Posts *Posts
 }
 
-// Org_Federation_PostsArgument is argument for "org.federation.Posts" message.
-type FederationService_Org_Federation_PostsArgument struct {
+// Org_Federation_GetPostsResponseArgument is argument for "org.federation.GetPostsResponse" message.
+type FederationService_Org_Federation_GetPostsResponseArgument struct {
+	Ids []string
+	FederationService_Org_Federation_GetPostsResponseVariable
+}
+
+// Org_Federation_PostsVariable represents variable definitions in "org.federation.Posts".
+type FederationService_Org_Federation_PostsVariable struct {
 	Ids             []string
 	Items           []*Posts_PostItem
-	PostIds         []string
 	Posts           []*post.Post
 	Res             *post.GetPostsResponse
 	SourceUserTypes []user.UserType
@@ -43,16 +47,32 @@ type FederationService_Org_Federation_PostsArgument struct {
 	Users           []*User
 }
 
+// Org_Federation_PostsArgument is argument for "org.federation.Posts" message.
+type FederationService_Org_Federation_PostsArgument struct {
+	PostIds []string
+	FederationService_Org_Federation_PostsVariable
+}
+
+// Org_Federation_Posts_PostItemVariable represents variable definitions in "org.federation.PostItem".
+type FederationService_Org_Federation_Posts_PostItemVariable struct {
+}
+
 // Org_Federation_Posts_PostItemArgument is argument for "org.federation.PostItem" message.
 type FederationService_Org_Federation_Posts_PostItemArgument struct {
 	Id string
+	FederationService_Org_Federation_Posts_PostItemVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+	Res  *user.GetUserResponse
+	User *user.User
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
-	Res    *user.GetUserResponse
-	User   *user.User
 	UserId string
+	FederationService_Org_Federation_UserVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -306,7 +326,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostsResponse(ctx context.
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Posts = value.vars.Posts
+	req.FederationService_Org_Federation_GetPostsResponseVariable.Posts = value.vars.Posts
 
 	// create a message value to be returned.
 	ret := &GetPostsResponse{}
@@ -674,13 +694,13 @@ func (s *FederationService) resolve_Org_Federation_Posts(ctx context.Context, re
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Ids = value.vars.Ids
-	req.Items = value.vars.Items
-	req.Posts = value.vars.Posts
-	req.Res = value.vars.Res
-	req.SourceUserTypes = value.vars.SourceUserTypes
-	req.UserTypes = value.vars.UserTypes
-	req.Users = value.vars.Users
+	req.FederationService_Org_Federation_PostsVariable.Ids = value.vars.Ids
+	req.FederationService_Org_Federation_PostsVariable.Items = value.vars.Items
+	req.FederationService_Org_Federation_PostsVariable.Posts = value.vars.Posts
+	req.FederationService_Org_Federation_PostsVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostsVariable.SourceUserTypes = value.vars.SourceUserTypes
+	req.FederationService_Org_Federation_PostsVariable.UserTypes = value.vars.UserTypes
+	req.FederationService_Org_Federation_PostsVariable.Users = value.vars.Users
 
 	// create a message value to be returned.
 	ret := &Posts{}
@@ -893,8 +913,8 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.User = value.vars.User
+	req.FederationService_Org_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_UserVariable.User = value.vars.User
 
 	// create a message value to be returned.
 	// `custom_resolver = true` in "grpc.federation.message" option.

--- a/generator/testdata/expected_minimum.go
+++ b/generator/testdata/expected_minimum.go
@@ -22,10 +22,15 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
+}
+
 // Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
 type FederationService_Org_Federation_GetPostResponseArgument struct {
 	Id   string
 	Type PostType
+	FederationService_Org_Federation_GetPostResponseVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -24,27 +24,47 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
-// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
-type FederationService_Org_Federation_GetResponseArgument struct {
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
 	Uid   *UserID
 	User  *User
 	User2 *User
 }
 
+// Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
+type FederationService_Org_Federation_GetResponseArgument struct {
+	FederationService_Org_Federation_GetResponseVariable
+}
+
+// Org_Federation_SubVariable represents variable definitions in "org.federation.Sub".
+type FederationService_Org_Federation_SubVariable struct {
+}
+
 // Org_Federation_SubArgument is argument for "org.federation.Sub" message.
 type FederationService_Org_Federation_SubArgument struct {
+	FederationService_Org_Federation_SubVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+	Res   *user.GetUserResponse
+	User  *user.User
+	XDef2 *Sub
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
-	Res    *user.GetUserResponse
-	User   *user.User
 	UserId string
-	XDef2  *Sub
+	FederationService_Org_Federation_UserVariable
+}
+
+// Org_Federation_UserIDVariable represents variable definitions in "org.federation.UserID".
+type FederationService_Org_Federation_UserIDVariable struct {
 }
 
 // Org_Federation_UserIDArgument is argument for "org.federation.UserID" message.
 type FederationService_Org_Federation_UserIDArgument struct {
+	FederationService_Org_Federation_UserIDVariable
 }
 
 // Org_Federation_User_NameArgument is custom resolver's argument for "name" field of "org.federation.User" message.
@@ -392,9 +412,9 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Uid = value.vars.Uid
-	req.User = value.vars.User
-	req.User2 = value.vars.User2
+	req.FederationService_Org_Federation_GetResponseVariable.Uid = value.vars.Uid
+	req.FederationService_Org_Federation_GetResponseVariable.User = value.vars.User
+	req.FederationService_Org_Federation_GetResponseVariable.User2 = value.vars.User2
 
 	// create a message value to be returned.
 	ret := &GetResponse{}
@@ -591,9 +611,9 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.User = value.vars.User
-	req.XDef2 = value.vars.XDef2
+	req.FederationService_Org_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_UserVariable.User = value.vars.User
+	req.FederationService_Org_Federation_UserVariable.XDef2 = value.vars.XDef2
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -24,27 +24,47 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetResponseVariable represents variable definitions in "org.federation.GetResponse".
+type FederationService_Org_Federation_GetResponseVariable struct {
+	Sel *UserSelection
+}
+
 // Org_Federation_GetResponseArgument is argument for "org.federation.GetResponse" message.
 type FederationService_Org_Federation_GetResponseArgument struct {
-	Sel *UserSelection
+	FederationService_Org_Federation_GetResponseVariable
+}
+
+// Org_Federation_MVariable represents variable definitions in "org.federation.M".
+type FederationService_Org_Federation_MVariable struct {
 }
 
 // Org_Federation_MArgument is argument for "org.federation.M" message.
 type FederationService_Org_Federation_MArgument struct {
+	FederationService_Org_Federation_MVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
 }
 
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	UserId string
+	FederationService_Org_Federation_UserVariable
+}
+
+// Org_Federation_UserSelectionVariable represents variable definitions in "org.federation.UserSelection".
+type FederationService_Org_Federation_UserSelectionVariable struct {
+	M  *M
+	Ua *User
+	Ub *User
+	Uc *User
 }
 
 // Org_Federation_UserSelectionArgument is argument for "org.federation.UserSelection" message.
 type FederationService_Org_Federation_UserSelectionArgument struct {
-	M     *M
-	Ua    *User
-	Ub    *User
-	Uc    *User
 	Value string
+	FederationService_Org_Federation_UserSelectionVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -270,7 +290,7 @@ func (s *FederationService) resolve_Org_Federation_GetResponse(ctx context.Conte
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Sel = value.vars.Sel
+	req.FederationService_Org_Federation_GetResponseVariable.Sel = value.vars.Sel
 
 	// create a message value to be returned.
 	ret := &GetResponse{}
@@ -510,10 +530,10 @@ func (s *FederationService) resolve_Org_Federation_UserSelection(ctx context.Con
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.M = value.vars.M
-	req.Ua = value.vars.Ua
-	req.Ub = value.vars.Ub
-	req.Uc = value.vars.Uc
+	req.FederationService_Org_Federation_UserSelectionVariable.M = value.vars.M
+	req.FederationService_Org_Federation_UserSelectionVariable.Ua = value.vars.Ua
+	req.FederationService_Org_Federation_UserSelectionVariable.Ub = value.vars.Ub
+	req.FederationService_Org_Federation_UserSelectionVariable.Uc = value.vars.Uc
 
 	// create a message value to be returned.
 	ret := &UserSelection{}

--- a/generator/testdata/expected_ref_env.go
+++ b/generator/testdata/expected_ref_env.go
@@ -22,8 +22,13 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_ConstantVariable represents variable definitions in "org.federation.Constant".
+type RefEnvService_Org_Federation_ConstantVariable struct {
+}
+
 // Org_Federation_ConstantArgument is argument for "org.federation.Constant" message.
 type RefEnvService_Org_Federation_ConstantArgument struct {
+	RefEnvService_Org_Federation_ConstantVariable
 }
 
 // RefEnvServiceConfig configuration required to initialize the service that use GRPC Federation.

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -24,22 +24,37 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_GetPostResponse1Variable represents variable definitions in "org.federation.GetPostResponse1".
+type FederationService_Org_Federation_GetPostResponse1Variable struct {
+	Post *Post
+}
+
 // Org_Federation_GetPostResponse1Argument is argument for "org.federation.GetPostResponse1" message.
 type FederationService_Org_Federation_GetPostResponse1Argument struct {
-	Id   string
+	Id string
+	FederationService_Org_Federation_GetPostResponse1Variable
+}
+
+// Org_Federation_GetPostResponse2Variable represents variable definitions in "org.federation.GetPostResponse2".
+type FederationService_Org_Federation_GetPostResponse2Variable struct {
 	Post *Post
 }
 
 // Org_Federation_GetPostResponse2Argument is argument for "org.federation.GetPostResponse2" message.
 type FederationService_Org_Federation_GetPostResponse2Argument struct {
-	Id   string
-	Post *Post
+	Id string
+	FederationService_Org_Federation_GetPostResponse2Variable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
+	Res *post.GetPostResponse
 }
 
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
 type FederationService_Org_Federation_PostArgument struct {
-	Id  string
-	Res *post.GetPostResponse
+	Id string
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -290,7 +305,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse1(ctx context.
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponse1Variable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse1{}
@@ -374,7 +389,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse2(ctx context.
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponse2Variable.Post = value.vars.Post
 
 	// create a message value to be returned.
 	ret := &GetPostResponse2{}
@@ -461,7 +476,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
 
 	// create a message value to be returned.
 	ret := &Post{}

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -38,39 +38,59 @@ var Item_ItemType_attrMap = grpcfed.EnumAttributeMap[Item_ItemType]{
 	},
 }
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	E        Item_ItemType
-	Id       string
 	MapValue map[int64]string
 	Post     *Post
 	Uuid     *grpcfedcel.UUID
+}
+
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_MVariable represents variable definitions in "org.federation.M".
+type FederationService_Org_Federation_MVariable struct {
 }
 
 // Org_Federation_MArgument is argument for "org.federation.M" message.
 type FederationService_Org_Federation_MArgument struct {
 	X uint64
 	Y user.Item_ItemType
+	FederationService_Org_Federation_MVariable
 }
 
-// Org_Federation_PostArgument is argument for "org.federation.Post" message.
-type FederationService_Org_Federation_PostArgument struct {
-	Id   string
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
 	M    *M
 	Post *post.Post
 	Res  *post.GetPostResponse
 	User *User
 }
 
+// Org_Federation_PostArgument is argument for "org.federation.Post" message.
+type FederationService_Org_Federation_PostArgument struct {
+	Id string
+	FederationService_Org_Federation_PostVariable
+}
+
+// Org_Federation_UserVariable represents variable definitions in "org.federation.User".
+type FederationService_Org_Federation_UserVariable struct {
+	Res   *user.GetUserResponse
+	User  *user.User
+	XDef2 *M
+}
+
 // Org_Federation_UserArgument is argument for "org.federation.User" message.
 type FederationService_Org_Federation_UserArgument struct {
 	Content string
 	Id      string
-	Res     *user.GetUserResponse
 	Title   string
-	User    *user.User
 	UserId  string
-	XDef2   *M
+	FederationService_Org_Federation_UserVariable
 }
 
 // Org_Federation_User_AgeArgument is custom resolver's argument for "age" field of "org.federation.User" message.
@@ -78,8 +98,13 @@ type FederationService_Org_Federation_User_AgeArgument struct {
 	*FederationService_Org_Federation_UserArgument
 }
 
+// Org_Federation_ZVariable represents variable definitions in "org.federation.Z".
+type FederationService_Org_Federation_ZVariable struct {
+}
+
 // Org_Federation_ZArgument is argument for "org.federation.Z" message.
 type FederationService_Org_Federation_ZArgument struct {
+	FederationService_Org_Federation_ZVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -465,10 +490,10 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.E = value.vars.E
-	req.MapValue = value.vars.MapValue
-	req.Post = value.vars.Post
-	req.Uuid = value.vars.Uuid
+	req.FederationService_Org_Federation_GetPostResponseVariable.E = value.vars.E
+	req.FederationService_Org_Federation_GetPostResponseVariable.MapValue = value.vars.MapValue
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.Uuid = value.vars.Uuid
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}
@@ -915,10 +940,10 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.M = value.vars.M
-	req.Post = value.vars.Post
-	req.Res = value.vars.Res
-	req.User = value.vars.User
+	req.FederationService_Org_Federation_PostVariable.M = value.vars.M
+	req.FederationService_Org_Federation_PostVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_PostVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_PostVariable.User = value.vars.User
 
 	// create a message value to be returned.
 	ret := &Post{}
@@ -1133,9 +1158,9 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Res = value.vars.Res
-	req.User = value.vars.User
-	req.XDef2 = value.vars.XDef2
+	req.FederationService_Org_Federation_UserVariable.Res = value.vars.Res
+	req.FederationService_Org_Federation_UserVariable.User = value.vars.User
+	req.FederationService_Org_Federation_UserVariable.XDef2 = value.vars.XDef2
 
 	// create a message value to be returned.
 	ret := &User{}

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -41,6 +41,7 @@ var Item_ItemType_attrMap = grpcfed.EnumAttributeMap[Item_ItemType]{
 // Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
 type FederationService_Org_Federation_GetPostResponseVariable struct {
 	E        Item_ItemType
+	Id       int64
 	MapValue map[int64]string
 	Post     *Post
 	Uuid     *grpcfedcel.UUID
@@ -327,6 +328,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 		*grpcfed.LocalValue
 		vars struct {
 			E        Item_ItemType
+			Id       int64
 			MapValue map[int64]string
 			Post     *Post
 			Uuid     *grpcfedcel.UUID
@@ -444,9 +446,29 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 		})
 	}
 
+	/*
+		def {
+		  name: "id"
+		  by: "100"
+		}
+	*/
+	def_id := func(ctx context.Context) error {
+		return grpcfed.EvalDef(ctx, value, grpcfed.Def[int64, *localValueType]{
+			Name: `id`,
+			Type: grpcfed.CELIntType,
+			Setter: func(value *localValueType, v int64) error {
+				value.vars.Id = v
+				return nil
+			},
+			By:           `100`,
+			ByCacheIndex: 5,
+		})
+	}
+
 	// A tree view of message dependencies is shown below.
 	/*
 	           e ─┐
+	          id ─┤
 	   map_value ─┤
 	        post ─┤
 	        uuid ─┤
@@ -455,6 +477,14 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 
 	grpcfed.GoWithRecover(eg, func() (any, error) {
 		if err := def_e(ctx1); err != nil {
+			grpcfed.RecordErrorToSpan(ctx1, err)
+			return nil, err
+		}
+		return nil, nil
+	})
+
+	grpcfed.GoWithRecover(eg, func() (any, error) {
+		if err := def_id(ctx1); err != nil {
 			grpcfed.RecordErrorToSpan(ctx1, err)
 			return nil, err
 		}
@@ -491,6 +521,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 
 	// assign named parameters to message arguments to pass to the custom resolver.
 	req.FederationService_Org_Federation_GetPostResponseVariable.E = value.vars.E
+	req.FederationService_Org_Federation_GetPostResponseVariable.Id = value.vars.Id
 	req.FederationService_Org_Federation_GetPostResponseVariable.MapValue = value.vars.MapValue
 	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
 	req.FederationService_Org_Federation_GetPostResponseVariable.Uuid = value.vars.Uuid
@@ -503,7 +534,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*Post]{
 		Value:      value,
 		Expr:       `post`,
-		CacheIndex: 5,
+		CacheIndex: 6,
 		Setter: func(v *Post) error {
 			ret.Post = v
 			return nil
@@ -516,7 +547,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 		Value:      value,
 		Expr:       `'foo'`,
-		CacheIndex: 6,
+		CacheIndex: 7,
 		Setter: func(v string) error {
 			ret.Const = v
 			return nil
@@ -529,7 +560,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 		Value:      value,
 		Expr:       `uuid.string()`,
-		CacheIndex: 7,
+		CacheIndex: 8,
 		Setter: func(v string) error {
 			ret.Uuid = v
 			return nil
@@ -542,7 +573,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 		Value:      value,
 		Expr:       `org.federation.Item.ItemType.name(org.federation.Item.ItemType.ITEM_TYPE_1)`,
-		CacheIndex: 8,
+		CacheIndex: 9,
 		Setter: func(v string) error {
 			ret.EnumName = v
 			return nil
@@ -555,7 +586,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[Item_ItemType]{
 		Value:      value,
 		Expr:       `org.federation.Item.ItemType.value('ITEM_TYPE_1')`,
-		CacheIndex: 9,
+		CacheIndex: 10,
 		Setter: func(v Item_ItemType) error {
 			enumValueValue, err := s.cast_Org_Federation_Item_ItemType__to__int32(v)
 			if err != nil {
@@ -572,7 +603,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[map[int64]string]{
 		Value:      value,
 		Expr:       `map_value`,
-		CacheIndex: 10,
+		CacheIndex: 11,
 		Setter: func(v map[int64]string) error {
 			mapValueValue, err := s.cast_map_int64_string__to__map_int32_string(v)
 			if err != nil {
@@ -589,7 +620,7 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[Item_ItemType]{
 		Value:      value,
 		Expr:       `e`,
-		CacheIndex: 11,
+		CacheIndex: 12,
 		Setter: func(v Item_ItemType) error {
 			ret.ItemType = v
 			return nil
@@ -602,9 +633,22 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 		Value:      value,
 		Expr:       `Item.ItemType.attr(e, 'en')`,
-		CacheIndex: 12,
+		CacheIndex: 13,
 		Setter: func(v string) error {
 			ret.ItemTypeText = v
+			return nil
+		},
+	}); err != nil {
+		grpcfed.RecordErrorToSpan(ctx, err)
+		return nil, err
+	}
+	// (grpc.federation.field).by = "id"
+	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[int64]{
+		Value:      value,
+		Expr:       `id`,
+		CacheIndex: 14,
+		Setter: func(v int64) error {
+			ret.DifferentTypeId = v
 			return nil
 		},
 	}); err != nil {
@@ -638,7 +682,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *F
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 		Value:      value,
 		Expr:       `'foo'`,
-		CacheIndex: 13,
+		CacheIndex: 15,
 		Setter: func(v string) error {
 			ret.Foo = v
 			return nil
@@ -651,7 +695,7 @@ func (s *FederationService) resolve_Org_Federation_M(ctx context.Context, req *F
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[int64]{
 		Value:      value,
 		Expr:       `1`,
-		CacheIndex: 14,
+		CacheIndex: 16,
 		Setter: func(v int64) error {
 			ret.Bar = v
 			return nil
@@ -706,7 +750,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:      value,
 					Expr:       `$.id`,
-					CacheIndex: 15,
+					CacheIndex: 17,
 					Setter: func(v string) error {
 						args.Id = v
 						return nil
@@ -722,7 +766,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 					return grpcfed.WithRetry(ctx, &grpcfed.RetryParam[post.GetPostResponse]{
 						Value:      value,
 						If:         `true`,
-						CacheIndex: 16,
+						CacheIndex: 18,
 						BackOff:    b,
 						Body: func() (*post.GetPostResponse, error) {
 							return s.client.Org_Post_PostServiceClient.GetPost(ctx, args)
@@ -755,7 +799,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				return nil
 			},
 			By:           `res.post`,
-			ByCacheIndex: 17,
+			ByCacheIndex: 19,
 		})
 	}
 
@@ -782,7 +826,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*post.Post]{
 					Value:      value,
 					Expr:       `post`,
-					CacheIndex: 18,
+					CacheIndex: 20,
 					Setter: func(v *post.Post) error {
 						args.Id = v.GetId()
 						args.Title = v.GetTitle()
@@ -856,7 +900,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[int64]{
 					Value:      value,
 					Expr:       `10`,
-					CacheIndex: 19,
+					CacheIndex: 21,
 					Setter: func(v int64) error {
 						xValue, err := s.cast_int64__to__uint64(v)
 						if err != nil {
@@ -872,7 +916,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[int64]{
 					Value:      value,
 					Expr:       `1`,
-					CacheIndex: 20,
+					CacheIndex: 22,
 					Setter: func(v int64) error {
 						yValue, err := s.cast_int64__to__Org_User_Item_ItemType(v)
 						if err != nil {
@@ -956,7 +1000,7 @@ func (s *FederationService) resolve_Org_Federation_Post(ctx context.Context, req
 	if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[*User]{
 		Value:      value,
 		Expr:       `user`,
-		CacheIndex: 21,
+		CacheIndex: 23,
 		Setter: func(v *User) error {
 			ret.User = v
 			return nil
@@ -1011,7 +1055,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[string]{
 					Value:      value,
 					Expr:       `$.user_id`,
-					CacheIndex: 22,
+					CacheIndex: 24,
 					Setter: func(v string) error {
 						args.Id = v
 						return nil
@@ -1033,7 +1077,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 					return grpcfed.WithRetry(ctx, &grpcfed.RetryParam[user.GetUserResponse]{
 						Value:      value,
 						If:         `error.code != google.rpc.Code.UNIMPLEMENTED`,
-						CacheIndex: 23,
+						CacheIndex: 25,
 						BackOff:    b,
 						Body: func() (*user.GetUserResponse, error) {
 							return s.client.Org_User_UserServiceClient.GetUser(ctx, args)
@@ -1066,7 +1110,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				return nil
 			},
 			By:           `res.user`,
-			ByCacheIndex: 24,
+			ByCacheIndex: 26,
 		})
 	}
 
@@ -1096,7 +1140,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[uint64]{
 					Value:      value,
 					Expr:       `uint(2)`,
-					CacheIndex: 25,
+					CacheIndex: 27,
 					Setter: func(v uint64) error {
 						args.X = v
 						return nil
@@ -1108,7 +1152,7 @@ func (s *FederationService) resolve_Org_Federation_User(ctx context.Context, req
 				if err := grpcfed.SetCELValue(ctx, &grpcfed.SetCELValueParam[user.Item_ItemType]{
 					Value:      value,
 					Expr:       `org.user.Item.ItemType.value('ITEM_TYPE_2')`,
-					CacheIndex: 26,
+					CacheIndex: 28,
 					Setter: func(v user.Item_ItemType) error {
 						args.Y = v
 						return nil
@@ -1443,6 +1487,7 @@ func (s *FederationService) logvalue_Org_Federation_GetPostResponse(v *GetPostRe
 		slog.Any("map_value", s.logvalue_Org_Federation_GetPostResponse_MapValueEntry(v.GetMapValue())),
 		slog.String("item_type", s.logvalue_Org_Federation_Item_ItemType(v.GetItemType()).String()),
 		slog.String("item_type_text", v.GetItemTypeText()),
+		slog.Int64("different_type_id", v.GetDifferentTypeId()),
 	)
 }
 

--- a/generator/testdata/expected_validation.go
+++ b/generator/testdata/expected_validation.go
@@ -22,21 +22,36 @@ var (
 	_ = reflect.Invalid // to avoid "imported and not used error"
 )
 
+// Org_Federation_CustomMessageVariable represents variable definitions in "org.federation.CustomMessage".
+type FederationService_Org_Federation_CustomMessageVariable struct {
+}
+
 // Org_Federation_CustomMessageArgument is argument for "org.federation.CustomMessage" message.
 type FederationService_Org_Federation_CustomMessageArgument struct {
 	Message string
+	FederationService_Org_Federation_CustomMessageVariable
 }
 
-// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
-type FederationService_Org_Federation_GetPostResponseArgument struct {
-	Id                  string
+// Org_Federation_GetPostResponseVariable represents variable definitions in "org.federation.GetPostResponse".
+type FederationService_Org_Federation_GetPostResponseVariable struct {
 	Post                *Post
 	XDef2ErrDetail0Msg0 *CustomMessage
 	XDef2ErrDetail0Msg1 *CustomMessage
 }
 
+// Org_Federation_GetPostResponseArgument is argument for "org.federation.GetPostResponse" message.
+type FederationService_Org_Federation_GetPostResponseArgument struct {
+	Id string
+	FederationService_Org_Federation_GetPostResponseVariable
+}
+
+// Org_Federation_PostVariable represents variable definitions in "org.federation.Post".
+type FederationService_Org_Federation_PostVariable struct {
+}
+
 // Org_Federation_PostArgument is argument for "org.federation.Post" message.
 type FederationService_Org_Federation_PostArgument struct {
+	FederationService_Org_Federation_PostVariable
 }
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
@@ -562,9 +577,9 @@ func (s *FederationService) resolve_Org_Federation_GetPostResponse(ctx context.C
 	}
 
 	// assign named parameters to message arguments to pass to the custom resolver.
-	req.Post = value.vars.Post
-	req.XDef2ErrDetail0Msg0 = value.vars.XDef2ErrDetail0Msg0
-	req.XDef2ErrDetail0Msg1 = value.vars.XDef2ErrDetail0Msg1
+	req.FederationService_Org_Federation_GetPostResponseVariable.Post = value.vars.Post
+	req.FederationService_Org_Federation_GetPostResponseVariable.XDef2ErrDetail0Msg0 = value.vars.XDef2ErrDetail0Msg0
+	req.FederationService_Org_Federation_GetPostResponseVariable.XDef2ErrDetail0Msg1 = value.vars.XDef2ErrDetail0Msg1
 
 	// create a message value to be returned.
 	ret := &GetPostResponse{}

--- a/resolver/format_test.go
+++ b/resolver/format_test.go
@@ -46,6 +46,10 @@ func TestProtoFormat(t *testing.T) {
         by: "org.user.Item.ItemType.value('ITEM_TYPE_2')"
       }
     }
+    def {
+      name: "id"
+      by: "100"
+    }
   }`,
 				"Post": `
   option (grpc.federation.message) = {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -459,6 +459,11 @@ func TestSimpleAggregation(t *testing.T) {
 					resolver.StringType,
 					testutil.NewFieldRuleBuilder(resolver.NewByValue("Item.ItemType.attr(e, 'en')", resolver.StringType)).Build(t),
 				).
+				AddFieldWithRule(
+					"different_type_id",
+					resolver.Int64Type,
+					testutil.NewFieldRuleBuilder(resolver.NewByValue("id", resolver.Int64Type)).Build(t),
+				).
 				SetRule(
 					testutil.NewMessageRuleBuilder().
 						AddVariableDefinition(
@@ -518,6 +523,13 @@ func TestSimpleAggregation(t *testing.T) {
 								).
 								Build(t),
 						).
+						AddVariableDefinition(
+							testutil.NewVariableDefinitionBuilder().
+								SetName("id").
+								SetUsed(true).
+								SetBy(testutil.NewCELValueBuilder("100", resolver.Int64Type).Build(t)).
+								Build(t),
+						).
 						SetMessageArgument(ref.Message(t, "org.federation", "GetPostResponseArgument")).
 						SetDependencyGraph(
 							testutil.NewDependencyGraphBuilder().
@@ -525,6 +537,7 @@ func TestSimpleAggregation(t *testing.T) {
 								Build(t),
 						).
 						AddVariableDefinitionGroup(testutil.NewVariableDefinitionGroupByName("e")).
+						AddVariableDefinitionGroup(testutil.NewVariableDefinitionGroupByName("id")).
 						AddVariableDefinitionGroup(testutil.NewVariableDefinitionGroupByName("map_value")).
 						AddVariableDefinitionGroup(testutil.NewVariableDefinitionGroupByName("post")).
 						AddVariableDefinitionGroup(testutil.NewVariableDefinitionGroupByName("uuid")).

--- a/testdata/simple_aggregation.proto
+++ b/testdata/simple_aggregation.proto
@@ -34,6 +34,7 @@ message GetPostResponse {
     def { name: "uuid" by: "grpc.federation.uuid.newRandom()" }
     def { name: "map_value" by: "{1:'a', 2:'b', 3:'c'}" }
     def { name: "e" enum { name: "Item.ItemType" by: "org.user.Item.ItemType.value('ITEM_TYPE_2')" }}
+    def { name: "id" by: "100" }
   };
   org.federation.Post post = 1 [(grpc.federation.field).by = "post"];
   string const = 2 [(grpc.federation.field).by = "'foo'"];
@@ -43,6 +44,7 @@ message GetPostResponse {
   map<int32, string> map_value = 6 [(grpc.federation.field).by = "map_value"];
   Item.ItemType item_type = 7 [(grpc.federation.field).by = "e"];
   string item_type_text = 8 [(grpc.federation.field).by = "Item.ItemType.attr(e, 'en')"];
+  int64 different_type_id = 9 [(grpc.federation.field).by = "id"];
 }
 
 message Post {


### PR DESCRIPTION
Split variable definitions into a separate struct and embed it to avoid compilation errors caused by name conflicts.