### PR TITLE
feat(jetbrains-plugin): add semantic tokens support and enhance import path configuration UI

### DIFF
--- a/lsp/client/jetbrains/.gitignore
+++ b/lsp/client/jetbrains/.gitignore
@@ -2,3 +2,5 @@
 .idea
 .qodana
 build
+.intellijPlatform
+.kotlin

--- a/lsp/client/jetbrains/CHANGELOG.md
+++ b/lsp/client/jetbrains/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Issue with paths containing spaces in the previous text field approach
 - Better handling of empty and invalid path entries
 - Checkbox display issue in the Enabled column with explicit renderer and editor
+- Diagnostic messages containing HTML tags (like `<input>`) are now properly escaped to prevent UI rendering issues
 
 ### Deprecated
 - `importPaths` field in settings storage (will be removed in v0.3.0)

--- a/lsp/client/jetbrains/CHANGELOG.md
+++ b/lsp/client/jetbrains/CHANGELOG.md
@@ -19,10 +19,18 @@
 - Redesigned settings interface from single text field to table-based UI
 - Improved path management with better visual feedback
 - Enhanced user experience for managing multiple import paths
+- Migrated settings storage format from simple string list to structured entries with enable/disable state
 
 ### Fixed
 - Issue with paths containing spaces in the previous text field approach
 - Better handling of empty and invalid path entries
+- Checkbox display issue in the Enabled column with explicit renderer and editor
+
+### Deprecated
+- `importPaths` field in settings storage (will be removed in v0.3.0)
+  - Automatic migration: Existing configurations will be automatically converted to the new format
+  - The plugin maintains backward compatibility by reading from both old and new formats
+  - Only the new `importPathEntries` format will be supported from v0.3.0 onwards
 
 ## [0.1.0]
 

--- a/lsp/client/jetbrains/CHANGELOG.md
+++ b/lsp/client/jetbrains/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## [Unreleased]
 
-## [0.2.0]
-
 ### Added
 - New list-based UI for Proto Import Paths configuration
 - Enable/disable toggle for individual import paths
@@ -14,12 +12,19 @@
 - Variable expansion support for `~/` and `${PROJECT_ROOT}`
 - Toolbar buttons for add, remove, and reorder operations
 - "Validate Paths" button to verify all configured paths
+- Semantic tokens support for enhanced syntax highlighting of gRPC Federation annotations
+  - Token type mappings for proper colorization of proto elements
+  - Explicit semantic tokens request for proto files
 
 ### Changed
 - Redesigned settings interface from single text field to table-based UI
 - Improved path management with better visual feedback
 - Enhanced user experience for managing multiple import paths
 - Migrated settings storage format from simple string list to structured entries with enable/disable state
+- Updated to IntelliJ Platform Gradle Plugin 2.7.2 (latest)
+- Updated to Platform Version 2024.3.3 with Kotlin 2.1.0
+- Updated JVM toolchain from Java 17 to Java 21 (recommended for 2024.3.3)
+- Changed LSP server descriptor from ProjectWideLspServerDescriptor to LspServerDescriptor for proper semantic tokens support
 
 ### Fixed
 - Issue with paths containing spaces in the previous text field approach

--- a/lsp/client/jetbrains/CHANGELOG.md
+++ b/lsp/client/jetbrains/CHANGELOG.md
@@ -3,3 +3,31 @@
 # gRPC Federation Changelog
 
 ## [Unreleased]
+
+## [0.2.0]
+
+### Added
+- New list-based UI for Proto Import Paths configuration
+- Enable/disable toggle for individual import paths
+- File browser dialog for adding and editing paths
+- Path validation feature to check if directories exist
+- Variable expansion support for `~/` and `${PROJECT_ROOT}`
+- Toolbar buttons for add, remove, and reorder operations
+- "Validate Paths" button to verify all configured paths
+
+### Changed
+- Redesigned settings interface from single text field to table-based UI
+- Improved path management with better visual feedback
+- Enhanced user experience for managing multiple import paths
+
+### Fixed
+- Issue with paths containing spaces in the previous text field approach
+- Better handling of empty and invalid path entries
+
+## [0.1.0]
+
+### Added
+- Initial release of gRPC Federation IntelliJ plugin
+- Basic Language Server Protocol (LSP) integration
+- Proto import paths configuration
+- Support for `.proto` files with gRPC Federation annotations

--- a/lsp/client/jetbrains/README.md
+++ b/lsp/client/jetbrains/README.md
@@ -11,7 +11,7 @@ The gRPC Federation Language Server for JetBrains is a plugin designed for JetBr
 
 ## Requirements
 
-- **IntelliJ IDEA** 2023.3 or newer (Ultimate or Community Edition)
+- **IntelliJ IDEA Ultimate** 2023.3 or newer (This plugin requires Ultimate Edition)
 - **grpc-federation-language-server** installed and available in PATH
 - **Protocol Buffer** plugin (usually pre-installed)
 

--- a/lsp/client/jetbrains/README.md
+++ b/lsp/client/jetbrains/README.md
@@ -1,28 +1,91 @@
 <!-- Plugin description -->
 # gRPC Federation Language Server for JetBrains
-The gRPC Federation Language Server for JetBrains is a plugin designed for JetBrains IDEs to integrate with the gRPC Federation language server, offering various useful functionalities such as code completion.
+
+The gRPC Federation Language Server for JetBrains is a plugin designed for JetBrains IDEs to integrate with the gRPC Federation language server, providing enhanced development experience for Protocol Buffer files with gRPC Federation annotations.
 
 ## Features
 
-Currently, the following features are supported:
+- **Go to Definition** - Navigate to proto message and field definitions
+- **Diagnostics** - Real-time error detection and validation
+- **Code Completion** - Intelligent suggestions for gRPC Federation annotations
 
-- Goto Definition
-- Diagnostics
-- Code Completion
+## Requirements
+
+- **IntelliJ IDEA** 2023.3 or newer (Ultimate or Community Edition)
+- **grpc-federation-language-server** installed and available in PATH
+- **Protocol Buffer** plugin (usually pre-installed)
 
 ## Installation
-To utilize the plugin, `grpc-federation-language-server` must be accessible in the path. If Go is available, execute the following command to install it:
+
+### Step 1: Install the Language Server
+The plugin requires `grpc-federation-language-server` to be accessible in the system PATH. If Go is available, install it with:
 
 ```console
 $ go install github.com/mercari/grpc-federation/cmd/grpc-federation-language-server@latest
 ```
 
-Afterward, install the plugin from the Marketplace.
+Verify the installation:
+```console
+$ which grpc-federation-language-server
+```
 
-`Settings/Preferences` > `Plugins` > `Marketplace` > `Search for "gRPC Federation"` > `Install`
+### Step 2: Install the Plugin
+Install the plugin from JetBrains Marketplace:
+
+1. Open **Settings/Preferences** → **Plugins**
+2. Select **Marketplace** tab
+3. Search for **"gRPC Federation"**
+4. Click **Install** and restart the IDE
 
 ## Configuration
-For `grpc-federation-language-server` to function properly, provide proto import paths to import dependent proto files.
 
-`Settings/Preferences` > `Tools` > `gRPC Federation` > `Proto Import Paths`
+### Setting Import Paths
+Configure proto import paths for the language server to resolve dependencies:
+
+1. Navigate to **Settings/Preferences** → **Tools** → **gRPC Federation**
+2. In the **Proto Import Paths** section:
+   - Click **+** to add a new path
+   - Use the file browser to select directories
+   - Enable/disable paths using checkboxes
+   - Reorder paths using ↑/↓ buttons
+   - Click **Validate Paths** to verify all directories exist
+
+### Supported Path Variables
+
+- `~/` - User's home directory
+- `${PROJECT_ROOT}` - Current project root directory
+
+Example paths:
+```
+/usr/local/include
+${PROJECT_ROOT}/proto
+~/workspace/shared-protos
+```
+
+## Troubleshooting
+
+### Language Server Not Found
+If you see "grpc-federation-language-server not found" error:
+1. Ensure the language server is installed (see Installation section)
+2. Check if it's in your PATH: `which grpc-federation-language-server`
+3. Restart the IDE after installation
+
+### Proto Files Not Recognized
+If proto files are not being analyzed:
+1. Ensure the file extension is `.proto`
+2. Check that import paths are correctly configured
+3. Validate paths using the **Validate Paths** button
+4. Check the IDE logs: **Help** → **Show Log in Finder/Explorer**
+
+### Import Resolution Issues
+If imports are not being resolved:
+1. Add all necessary proto directories to import paths
+2. Ensure paths are in the correct order (more specific paths first)
+3. Check that all proto dependencies are available
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/mercari/grpc-federation/issues)
+- **Documentation**: [gRPC Federation Documentation](https://github.com/mercari/grpc-federation)
+
 <!-- Plugin description end -->

--- a/lsp/client/jetbrains/README.md
+++ b/lsp/client/jetbrains/README.md
@@ -13,7 +13,6 @@ The gRPC Federation Language Server for JetBrains is a plugin designed for JetBr
 
 - **IntelliJ IDEA Ultimate** 2023.3 or newer (This plugin requires Ultimate Edition)
 - **grpc-federation-language-server** installed and available in PATH
-- **Protocol Buffer** plugin (usually pre-installed)
 
 ## Installation
 

--- a/lsp/client/jetbrains/build.gradle.kts
+++ b/lsp/client/jetbrains/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 fun properties(key: String) = providers.gradleProperty(key)
 fun environment(key: String) = providers.environmentVariable(key)
@@ -7,7 +8,7 @@ fun environment(key: String) = providers.environmentVariable(key)
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
-    alias(libs.plugins.gradleIntelliJPlugin) // Gradle IntelliJ Plugin
+    alias(libs.plugins.gradleIntelliJPlugin) // Gradle IntelliJ Platform Plugin
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
     alias(libs.plugins.qodana) // Gradle Qodana Plugin
     alias(libs.plugins.kover) // Gradle Kover Plugin
@@ -19,58 +20,46 @@ version = properties("pluginVersion").get()
 // Configure project's dependencies
 repositories {
     mavenCentral()
+    
+    // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
 //    implementation(libs.annotations)
+
+    // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
+    intellijPlatform {
+        create(properties("platformType"), properties("platformVersion"))
+        
+        // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
+        bundledPlugins(properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) })
+        
+        pluginVerifier()
+        zipSigner()
+        testFramework(TestFrameworkType.Platform)
+    }
 }
 
 // Set the JVM language level used to build the project.
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
-// Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij {
-    pluginName = properties("pluginName")
-    version = properties("platformVersion")
-    type = properties("platformType")
-
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins = properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) }
-}
-
-// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-changelog {
-    groups.empty()
-    repositoryUrl = properties("pluginRepositoryUrl")
-}
-
-// Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
-koverReport {
-    defaults {
-        xml {
-            onCheck = true
-        }
-    }
-}
-
-tasks {
-    wrapper {
-        gradleVersion = properties("gradleVersion").get()
-    }
-
-    patchPluginXml {
+// Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
+intellijPlatform {
+    pluginConfiguration {
         version = properties("pluginVersion")
-        sinceBuild = properties("pluginSinceBuild")
-        untilBuild = properties("pluginUntilBuild")
-
+        name = properties("pluginName")
+        
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
             val start = "<!-- Plugin description -->"
             val end = "<!-- Plugin description end -->"
-
+            
             with (it.lines()) {
                 if (!containsAll(listOf(start, end))) {
                     throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
@@ -78,7 +67,7 @@ tasks {
                 subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
             }
         }
-
+        
         val changelog = project.changelog // local variable for configuration cache compatibility
         // Get the latest available change notes from the changelog file
         changeNotes = properties("pluginVersion").map { pluginVersion ->
@@ -91,29 +80,57 @@ tasks {
                 )
             }
         }
+        
+        ideaVersion {
+            sinceBuild = properties("pluginSinceBuild")
+            untilBuild = properties("pluginUntilBuild")
+        }
     }
-
-    // Configure UI tests plugin
-    // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
-    }
-
-    signPlugin {
-        certificateChain = environment("CERTIFICATE_CHAIN")
-        privateKey = environment("PRIVATE_KEY")
-        password = environment("PRIVATE_KEY_PASSWORD")
-    }
-
-    publishPlugin {
-        dependsOn("patchChangelog")
+    
+    publishing {
         token = environment("PUBLISH_TOKEN")
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels = properties("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+    
+    signing {
+        certificateChain = environment("CERTIFICATE_CHAIN")
+        privateKey = environment("PRIVATE_KEY")
+        password = environment("PRIVATE_KEY_PASSWORD")
+    }
+    
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
+}
+
+// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
+changelog {
+    groups.empty()
+    repositoryUrl = properties("pluginRepositoryUrl")
+}
+
+// Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
+kover {
+    reports {
+        filters {
+            excludes {
+                // Exclude generated code and build files if needed
+            }
+        }
+    }
+}
+
+tasks {
+    wrapper {
+        gradleVersion = properties("gradleVersion").get()
+    }
+    
+    publishPlugin {
+        dependsOn("patchChangelog")
     }
 }

--- a/lsp/client/jetbrains/gradle.properties
+++ b/lsp/client/jetbrains/gradle.properties
@@ -14,7 +14,7 @@ pluginSinceBuild = 233
 # 2. The plugin has minimal IDE integration surface area
 # 3. Users can install and test on newer versions without waiting for plugin updates
 # If compatibility issues arise in future versions, we can add the restriction then.
-# pluginUntilBuild = 241.*
+pluginUntilBuild = 
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/lsp/client/jetbrains/gradle.properties
+++ b/lsp/client/jetbrains/gradle.properties
@@ -7,7 +7,7 @@ pluginRepositoryUrl = https://github.com/mercari/grpc-federation
 pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 233
+pluginSinceBuild = 243
 # pluginUntilBuild is intentionally not set to allow the plugin to be compatible with future IDE versions.
 # This is relatively safe because:
 # 1. This plugin uses stable LSP (Language Server Protocol) APIs which are unlikely to break
@@ -18,14 +18,14 @@ pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 2023.3.5
+platformVersion = 2024.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.6
+gradleVersion = 8.10
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/lsp/client/jetbrains/gradle.properties
+++ b/lsp/client/jetbrains/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.github.mercari.grpcfederation
-pluginName = grpc-federation
+pluginName = gRPC Federation
 pluginRepositoryUrl = https://github.com/mercari/grpc-federation
 # SemVer format -> https://semver.org
 pluginVersion = 0.2.0

--- a/lsp/client/jetbrains/gradle.properties
+++ b/lsp/client/jetbrains/gradle.properties
@@ -4,11 +4,17 @@ pluginGroup = com.github.mercari.grpcfederation
 pluginName = grpc-federation
 pluginRepositoryUrl = https://github.com/mercari/grpc-federation
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.0
+pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild = 241.*
+# pluginUntilBuild is intentionally not set to allow the plugin to be compatible with future IDE versions.
+# This is relatively safe because:
+# 1. This plugin uses stable LSP (Language Server Protocol) APIs which are unlikely to break
+# 2. The plugin has minimal IDE integration surface area
+# 3. Users can install and test on newer versions without waiting for plugin updates
+# If compatibility issues arise in future versions, we can add the restriction then.
+# pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU

--- a/lsp/client/jetbrains/gradle/libs.versions.toml
+++ b/lsp/client/jetbrains/gradle/libs.versions.toml
@@ -3,18 +3,18 @@
 annotations = "24.1.0"
 
 # plugins
-kotlin = "1.9.23"
-changelog = "2.2.0"
-gradleIntelliJPlugin = "1.17.2"
-qodana = "2023.3.1"
-kover = "0.7.6"
+kotlin = "2.1.0"
+changelog = "2.2.1"
+gradleIntelliJPlugin = "2.7.2"
+qodana = "2024.2.5"
+kover = "0.8.3"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }
+gradleIntelliJPlugin = { id = "org.jetbrains.intellij.platform", version.ref = "gradleIntelliJPlugin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/lsp/GrpcFederationLspServerSupportProvider.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/lsp/GrpcFederationLspServerSupportProvider.kt
@@ -10,7 +10,10 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.platform.lsp.api.LspServerDescriptor
 import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
+import com.intellij.platform.lsp.api.customization.LspDiagnosticsSupport
 import com.intellij.psi.PsiFile
+import com.intellij.openapi.util.text.StringUtil
+import org.eclipse.lsp4j.Diagnostic
 
 internal class GrpcFederationLspServerSupportProvider : LspServerSupportProvider {
     override fun fileOpened(project: Project, file: VirtualFile, serverStarter: LspServerSupportProvider.LspServerStarter) {
@@ -22,6 +25,17 @@ internal class GrpcFederationLspServerSupportProvider : LspServerSupportProvider
 
 private class GrpcFederationLspServerDescriptor(project: Project) : LspServerDescriptor(project, "gRPC Federation") {
     override fun isSupportedFile(file: VirtualFile) = file.extension == "proto"
+    
+    // Enable diagnostics support with HTML escaping
+    override val lspDiagnosticsSupport: LspDiagnosticsSupport = object : LspDiagnosticsSupport() {
+        override fun getTooltip(diagnostic: Diagnostic): String {
+            // Escape HTML/XML entities in the diagnostic message to prevent UI issues
+            // The tooltip is rendered as HTML, so we need to escape special characters
+            // Always use <pre> tag to preserve formatting and ensure consistent display
+            val escapedMessage = StringUtil.escapeXmlEntities(diagnostic.message)
+            return "<pre>$escapedMessage</pre>"
+        }
+    }
     
     // Enable semantic tokens support for gRPC Federation syntax highlighting
     override val lspSemanticTokensSupport: LspSemanticTokensSupport = object : LspSemanticTokensSupport() {

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/lsp/GrpcFederationLspServerSupportProvider.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/lsp/GrpcFederationLspServerSupportProvider.kt
@@ -5,8 +5,12 @@ import com.github.mercari.grpcfederation.settings.projectSettings
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.platform.lsp.api.LspServerDescriptor
 import com.intellij.platform.lsp.api.LspServerSupportProvider
-import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
+import com.intellij.psi.PsiFile
 
 internal class GrpcFederationLspServerSupportProvider : LspServerSupportProvider {
     override fun fileOpened(project: Project, file: VirtualFile, serverStarter: LspServerSupportProvider.LspServerStarter) {
@@ -16,8 +20,68 @@ internal class GrpcFederationLspServerSupportProvider : LspServerSupportProvider
     }
 }
 
-private class GrpcFederationLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "gRPC Federation") {
+private class GrpcFederationLspServerDescriptor(project: Project) : LspServerDescriptor(project, "gRPC Federation") {
     override fun isSupportedFile(file: VirtualFile) = file.extension == "proto"
+    
+    // Enable semantic tokens support for gRPC Federation syntax highlighting
+    override val lspSemanticTokensSupport: LspSemanticTokensSupport = object : LspSemanticTokensSupport() {
+        override fun shouldAskServerForSemanticTokens(psiFile: PsiFile): Boolean {
+            // Always request semantic tokens for proto files
+            return psiFile.virtualFile?.extension == "proto"
+        }
+        
+        override fun getTextAttributesKey(
+            tokenType: String,
+            modifiers: List<String>
+        ): TextAttributesKey? {
+            return when (tokenType) {
+                // Types
+                "type" -> DefaultLanguageHighlighterColors.CLASS_NAME
+                "class" -> DefaultLanguageHighlighterColors.CLASS_NAME
+                "enum" -> DefaultLanguageHighlighterColors.CLASS_NAME
+                "interface" -> DefaultLanguageHighlighterColors.INTERFACE_NAME
+                "struct" -> DefaultLanguageHighlighterColors.CLASS_NAME
+                "typeParameter" -> DefaultLanguageHighlighterColors.CLASS_NAME
+                
+                // Variables and properties
+                "variable" -> when {
+                    modifiers.contains("readonly") -> DefaultLanguageHighlighterColors.CONSTANT
+                    modifiers.contains("static") -> DefaultLanguageHighlighterColors.STATIC_FIELD
+                    else -> DefaultLanguageHighlighterColors.LOCAL_VARIABLE
+                }
+                "property" -> when {
+                    modifiers.contains("static") -> DefaultLanguageHighlighterColors.STATIC_FIELD
+                    else -> DefaultLanguageHighlighterColors.INSTANCE_FIELD
+                }
+                "parameter" -> DefaultLanguageHighlighterColors.PARAMETER
+                
+                // Functions and methods
+                "function" -> when {
+                    modifiers.contains("declaration") -> DefaultLanguageHighlighterColors.FUNCTION_DECLARATION
+                    else -> DefaultLanguageHighlighterColors.FUNCTION_CALL
+                }
+                "method" -> when {
+                    modifiers.contains("static") -> DefaultLanguageHighlighterColors.STATIC_METHOD
+                    else -> DefaultLanguageHighlighterColors.INSTANCE_METHOD
+                }
+                
+                // Other
+                "namespace" -> DefaultLanguageHighlighterColors.CLASS_NAME
+                "enumMember" -> DefaultLanguageHighlighterColors.CONSTANT
+                "keyword" -> DefaultLanguageHighlighterColors.KEYWORD
+                "string" -> DefaultLanguageHighlighterColors.STRING
+                "number" -> DefaultLanguageHighlighterColors.NUMBER
+                "comment" -> DefaultLanguageHighlighterColors.LINE_COMMENT
+                "operator" -> DefaultLanguageHighlighterColors.OPERATION_SIGN
+                
+                // gRPC Federation specific
+                "decorator" -> DefaultLanguageHighlighterColors.METADATA  // for annotations like grpc.federation
+                
+                else -> null
+            }
+        }
+    }
+    
     override fun createCommandLine(): GeneralCommandLine {
         val state = project.projectSettings.currentState
         val cmd = mutableListOf<String>()

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/lsp/GrpcFederationLspServerSupportProvider.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/lsp/GrpcFederationLspServerSupportProvider.kt
@@ -1,5 +1,6 @@
 package com.github.mercari.grpcfederation.lsp
 
+import com.github.mercari.grpcfederation.settings.PathUtils
 import com.github.mercari.grpcfederation.settings.projectSettings
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
@@ -22,30 +23,21 @@ private class GrpcFederationLspServerDescriptor(project: Project) : ProjectWideL
         val cmd = mutableListOf<String>()
         cmd.add("grpc-federation-language-server")
         
-        // Use new format if available, otherwise fall back to old format
+        // Use new format (importPathEntries) if available, otherwise fall back to legacy format
+        // TODO: Remove legacy format support in v0.3.0
         val paths = if (state.importPathEntries.isNotEmpty()) {
             state.importPathEntries.filter { it.enabled }.map { it.path }
         } else {
+            // Legacy format: all paths are considered enabled
             state.importPaths
         }
         
         for (p in paths) {
             if (p.isNotEmpty()) {
                 cmd.add("-I")
-                cmd.add(expandPath(project, p))
+                cmd.add(PathUtils.expandPath(p, project))
             }
         }
         return GeneralCommandLine(cmd)
-    }
-    
-    private fun expandPath(project: Project, path: String): String {
-        var expanded = path
-        if (path.startsWith("~/")) {
-            expanded = System.getProperty("user.home") + path.substring(1)
-        }
-        if (path.contains("\${PROJECT_ROOT}")) {
-            expanded = expanded.replace("\${PROJECT_ROOT}", project.basePath ?: "")
-        }
-        return expanded
     }
 }

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ImportPathTableModel.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ImportPathTableModel.kt
@@ -1,0 +1,87 @@
+package com.github.mercari.grpcfederation.settings
+
+import com.intellij.util.ui.ItemRemovable
+import javax.swing.table.AbstractTableModel
+
+class ImportPathTableModel : AbstractTableModel(), ItemRemovable {
+    private val entries = mutableListOf<ProjectSettingsService.ImportPathEntry>()
+    
+    companion object {
+        private const val COLUMN_ENABLED = 0
+        private const val COLUMN_PATH = 1
+        private val COLUMN_NAMES = arrayOf("Enabled", "Import Path")
+        private val COLUMN_CLASSES = arrayOf(Boolean::class.java, String::class.java)
+    }
+
+    fun getEntries(): List<ProjectSettingsService.ImportPathEntry> = entries.toList()
+    
+    fun setEntries(newEntries: List<ProjectSettingsService.ImportPathEntry>) {
+        entries.clear()
+        entries.addAll(newEntries)
+        fireTableDataChanged()
+    }
+    
+    fun addEntry(entry: ProjectSettingsService.ImportPathEntry) {
+        entries.add(entry)
+        fireTableRowsInserted(entries.size - 1, entries.size - 1)
+    }
+    
+    fun removeEntry(index: Int) {
+        if (index >= 0 && index < entries.size) {
+            entries.removeAt(index)
+            fireTableRowsDeleted(index, index)
+        }
+    }
+    
+    fun moveUp(index: Int) {
+        if (index > 0 && index < entries.size) {
+            val entry = entries.removeAt(index)
+            entries.add(index - 1, entry)
+            fireTableRowsUpdated(index - 1, index)
+        }
+    }
+    
+    fun moveDown(index: Int) {
+        if (index >= 0 && index < entries.size - 1) {
+            val entry = entries.removeAt(index)
+            entries.add(index + 1, entry)
+            fireTableRowsUpdated(index, index + 1)
+        }
+    }
+    
+    override fun getRowCount(): Int = entries.size
+    
+    override fun getColumnCount(): Int = COLUMN_NAMES.size
+    
+    override fun getColumnName(column: Int): String = COLUMN_NAMES[column]
+    
+    override fun getColumnClass(column: Int): Class<*> = COLUMN_CLASSES[column]
+    
+    override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean = true
+    
+    override fun getValueAt(rowIndex: Int, columnIndex: Int): Any? {
+        if (rowIndex >= entries.size) return null
+        
+        val entry = entries[rowIndex]
+        return when (columnIndex) {
+            COLUMN_ENABLED -> entry.enabled
+            COLUMN_PATH -> entry.path
+            else -> null
+        }
+    }
+    
+    override fun setValueAt(value: Any?, rowIndex: Int, columnIndex: Int) {
+        if (rowIndex >= entries.size) return
+        
+        val entry = entries[rowIndex]
+        when (columnIndex) {
+            COLUMN_ENABLED -> entry.enabled = value as? Boolean ?: true
+            COLUMN_PATH -> entry.path = value as? String ?: ""
+        }
+        fireTableCellUpdated(rowIndex, columnIndex)
+    }
+    
+    override fun removeRow(idx: Int) {
+        removeEntry(idx)
+    }
+}

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/PathUtils.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/PathUtils.kt
@@ -1,0 +1,33 @@
+package com.github.mercari.grpcfederation.settings
+
+import com.intellij.openapi.project.Project
+
+/**
+ * Utility object for path-related operations.
+ */
+object PathUtils {
+    /**
+     * Expands a path string by replacing user home directory (~) and project root variables.
+     *
+     * @param path The path to expand
+     * @param project The current project (used for ${PROJECT_ROOT} expansion)
+     * @return The expanded path
+     */
+    fun expandPath(path: String, project: Project): String {
+        var expanded = path
+        
+        // Expand user home directory
+        if (path.startsWith("~/")) {
+            expanded = System.getProperty("user.home") + path.substring(1)
+        }
+        
+        // Expand project root variable
+        if (path.contains("\${PROJECT_ROOT}")) {
+            expanded = expanded.replace("\${PROJECT_ROOT}", project.basePath ?: "")
+        }
+        
+        // Additional variable expansions can be added here in the future
+        
+        return expanded
+    }
+}

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsConfigurable.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsConfigurable.kt
@@ -13,8 +13,11 @@ import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.Component
 import java.io.File
 import javax.swing.*
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.TableCellRenderer
 
 class ProjectSettingsConfigurable(
         private val project: Project,
@@ -38,10 +41,34 @@ class ProjectSettingsConfigurable(
             intercellSpacing = JBUI.emptySize()
             emptyText.text = "No import paths configured"
             
-            // Set column widths
+            // Set column widths and configure checkbox for Enabled column
             columnModel.getColumn(0).apply {
                 preferredWidth = 60
                 maxWidth = 60
+                
+                // Set up checkbox renderer
+                val checkBoxRenderer = object : TableCellRenderer {
+                    private val checkBox = JCheckBox()
+                    override fun getTableCellRendererComponent(
+                        table: JTable,
+                        value: Any?,
+                        isSelected: Boolean,
+                        hasFocus: Boolean,
+                        row: Int,
+                        column: Int
+                    ): Component {
+                        checkBox.isSelected = value as? Boolean ?: true
+                        checkBox.horizontalAlignment = SwingConstants.CENTER
+                        checkBox.background = if (isSelected) table.selectionBackground else table.background
+                        return checkBox
+                    }
+                }
+                cellRenderer = checkBoxRenderer
+                
+                // Set up checkbox editor
+                cellEditor = DefaultCellEditor(JCheckBox().apply {
+                    horizontalAlignment = SwingConstants.CENTER
+                })
             }
             columnModel.getColumn(1).preferredWidth = 400
         }

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsConfigurable.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsConfigurable.kt
@@ -1,40 +1,263 @@
 package com.github.mercari.grpcfederation.settings
 
-import ai.grazie.nlp.utils.tokenizeByWhitespace
 import com.github.mercari.grpcfederation.GrpcFederationBundle
-import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.dsl.builder.*
+import com.intellij.openapi.ui.TextBrowseFolderListener
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.AnActionButton
+import com.intellij.ui.AnActionButtonRunnable
+import com.intellij.ui.TableUtil
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.io.File
+import javax.swing.*
 
 class ProjectSettingsConfigurable(
         private val project: Project,
-) : BoundConfigurable(GrpcFederationBundle.message("settings.grpcfederation.title")) {
-    private val state: ProjectSettingsService.State = project.projectSettings.state.copy()
-
-    override fun createPanel(): DialogPanel = panel {
-        row(GrpcFederationBundle.message("settings.grpcfederation.importpaths")) {
-            textField().bindText(
-                    { state.importPaths.joinToString(separator = " ") },
-                    { text -> state.importPaths = text.tokenizeByWhitespace() }
-            ).columns(COLUMNS_LARGE)
-                    .align(Align.FILL)
-                    .comment("For example, /path/to/proto. Paths should be absolute. To specify multiple paths, separate with spaces.")
+) : Configurable {
+    private var mainPanel: JPanel? = null
+    private val tableModel = ImportPathTableModel()
+    private var table: JBTable? = null
+    private var isModified = false
+    
+    override fun getDisplayName(): String = GrpcFederationBundle.message("settings.grpcfederation.title")
+    
+    override fun createComponent(): JComponent {
+        mainPanel = JPanel(BorderLayout())
+        
+        // Load current settings into the model
+        loadCurrentSettings()
+        
+        // Create the table
+        table = JBTable(tableModel).apply {
+            setShowGrid(false)
+            intercellSpacing = JBUI.emptySize()
+            emptyText.text = "No import paths configured"
+            
+            // Set column widths
+            columnModel.getColumn(0).apply {
+                preferredWidth = 60
+                maxWidth = 60
+            }
+            columnModel.getColumn(1).preferredWidth = 400
+        }
+        
+        // Create toolbar with buttons
+        val decorator = ToolbarDecorator.createDecorator(table!!)
+                .setAddAction { _ ->
+                    showAddPathDialog()
+                }
+                .setRemoveAction { _ ->
+                    table?.let { TableUtil.removeSelectedItems(it) }
+                    isModified = true
+                }
+                .setMoveUpAction { _ ->
+                    val selectedRow = table!!.selectedRow
+                    if (selectedRow > 0) {
+                        tableModel.moveUp(selectedRow)
+                        table!!.setRowSelectionInterval(selectedRow - 1, selectedRow - 1)
+                        isModified = true
+                    }
+                }
+                .setMoveDownAction { _ ->
+                    val selectedRow = table!!.selectedRow
+                    if (selectedRow >= 0 && selectedRow < tableModel.rowCount - 1) {
+                        tableModel.moveDown(selectedRow)
+                        table!!.setRowSelectionInterval(selectedRow + 1, selectedRow + 1)
+                        isModified = true
+                    }
+                }
+                .addExtraAction(object : AnActionButton("Browse", com.intellij.icons.AllIcons.Actions.Menu_open) {
+                    override fun actionPerformed(e: com.intellij.openapi.actionSystem.AnActionEvent) {
+                        val selectedRow = table!!.selectedRow
+                        if (selectedRow >= 0) {
+                            showEditPathDialog(selectedRow)
+                        }
+                    }
+                    
+                    override fun isEnabled(): Boolean {
+                        return table!!.selectedRow >= 0
+                    }
+                })
+        
+        // Add validation button
+        val validateButton = JButton("Validate Paths").apply {
+            addActionListener {
+                validatePaths()
+            }
+        }
+        
+        val decoratorPanel = decorator.createPanel()
+        
+        // Layout
+        mainPanel!!.add(decoratorPanel, BorderLayout.CENTER)
+        
+        val bottomPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.X_AXIS)
+            border = JBUI.Borders.emptyTop(8)
+            add(validateButton)
+            add(Box.createHorizontalGlue())
+        }
+        mainPanel!!.add(bottomPanel, BorderLayout.SOUTH)
+        
+        // Add listener for table changes
+        tableModel.addTableModelListener {
+            isModified = true
+        }
+        
+        return mainPanel!!
+    }
+    
+    private fun loadCurrentSettings() {
+        val currentState = project.projectSettings.currentState
+        
+        // Check if we have new format entries
+        if (currentState.importPathEntries.isNotEmpty()) {
+            tableModel.setEntries(currentState.importPathEntries.map {
+                ProjectSettingsService.ImportPathEntry(it.path, it.enabled)
+            })
+        } else if (currentState.importPaths.isNotEmpty()) {
+            // Migrate from old format
+            tableModel.setEntries(currentState.importPaths.map {
+                ProjectSettingsService.ImportPathEntry(it, true)
+            })
         }
     }
-
-    override fun reset() {
-        state.importPaths = project.projectSettings.state.importPaths
-        super.reset()
+    
+    private fun showAddPathDialog() {
+        val textField = TextFieldWithBrowseButton()
+        val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+        descriptor.title = "Select Proto Import Path"
+        textField.addBrowseFolderListener(TextBrowseFolderListener(descriptor, project))
+        
+        val panel = JPanel(BorderLayout()).apply {
+            add(JLabel("Path:"), BorderLayout.WEST)
+            add(textField, BorderLayout.CENTER)
+            preferredSize = JBUI.size(400, 30)
+        }
+        
+        val result = JOptionPane.showConfirmDialog(
+                mainPanel,
+                panel,
+                "Add Import Path",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.PLAIN_MESSAGE
+        )
+        
+        if (result == JOptionPane.OK_OPTION && textField.text.isNotEmpty()) {
+            tableModel.addEntry(ProjectSettingsService.ImportPathEntry(textField.text, true))
+            isModified = true
+        }
     }
-
-    override fun apply() {
-        super.apply()
-        project.projectSettings.state = state
+    
+    private fun showEditPathDialog(row: Int) {
+        val currentPath = tableModel.getValueAt(row, 1) as String
+        val textField = TextFieldWithBrowseButton()
+        textField.text = currentPath
+        
+        val descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
+        descriptor.title = "Select Proto Import Path"
+        textField.addBrowseFolderListener(TextBrowseFolderListener(descriptor, project))
+        
+        val panel = JPanel(BorderLayout()).apply {
+            add(JLabel("Path:"), BorderLayout.WEST)
+            add(textField, BorderLayout.CENTER)
+            preferredSize = JBUI.size(400, 30)
+        }
+        
+        val result = JOptionPane.showConfirmDialog(
+                mainPanel,
+                panel,
+                "Edit Import Path",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.PLAIN_MESSAGE
+        )
+        
+        if (result == JOptionPane.OK_OPTION && textField.text.isNotEmpty()) {
+            tableModel.setValueAt(textField.text, row, 1)
+            isModified = true
+        }
     }
-
+    
+    private fun validatePaths() {
+        val entries = tableModel.getEntries()
+        val invalidPaths = mutableListOf<String>()
+        
+        for (entry in entries) {
+            if (entry.enabled) {
+                val path = expandPath(entry.path)
+                val file = File(path)
+                if (!file.exists() || !file.isDirectory) {
+                    invalidPaths.add(entry.path)
+                }
+            }
+        }
+        
+        if (invalidPaths.isEmpty()) {
+            JOptionPane.showMessageDialog(
+                    mainPanel,
+                    "All enabled paths are valid.",
+                    "Validation Result",
+                    JOptionPane.INFORMATION_MESSAGE
+            )
+        } else {
+            JOptionPane.showMessageDialog(
+                    mainPanel,
+                    "The following paths are invalid:\n" + invalidPaths.joinToString("\n"),
+                    "Validation Result",
+                    JOptionPane.WARNING_MESSAGE
+            )
+        }
+    }
+    
+    private fun expandPath(path: String): String {
+        var expanded = path
+        if (path.startsWith("~/")) {
+            expanded = System.getProperty("user.home") + path.substring(1)
+        }
+        // Could add more variable expansions here like ${PROJECT_ROOT}
+        if (path.contains("\${PROJECT_ROOT}")) {
+            expanded = expanded.replace("\${PROJECT_ROOT}", project.basePath ?: "")
+        }
+        return expanded
+    }
+    
     override fun isModified(): Boolean {
-        if (super.isModified()) return true
-        return project.projectSettings.state != state
+        if (isModified) return true
+        
+        val currentEntries = project.projectSettings.currentState.importPathEntries
+        val tableEntries = tableModel.getEntries()
+        
+        if (currentEntries.size != tableEntries.size) return true
+        
+        return !currentEntries.zip(tableEntries).all { (current, table) ->
+            current.path == table.path && current.enabled == table.enabled
+        }
+    }
+    
+    override fun apply() {
+        val entries = tableModel.getEntries()
+        val newState = ProjectSettingsService.State(
+                importPaths = entries.filter { it.enabled }.map { it.path }.toMutableList(),
+                importPathEntries = entries.map { 
+                    ProjectSettingsService.ImportPathEntry(it.path, it.enabled) 
+                }.toMutableList()
+        )
+        project.projectSettings.currentState = newState
+        isModified = false
+    }
+    
+    override fun reset() {
+        loadCurrentSettings()
+        isModified = false
+    }
+    
+    override fun disposeUIResources() {
+        mainPanel = null
+        table = null
     }
 }

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsService.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsService.kt
@@ -13,8 +13,25 @@ interface ProjectSettingsService {
 
     @Tag("GrpcFederationSettings")
     data class State(
+            /**
+             * Legacy field for backward compatibility.
+             * Contains only enabled paths for compatibility with older plugin versions.
+             * 
+             * @deprecated This field will be removed in version 0.3.0.
+             * Migration plan:
+             * - v0.2.0 (current): Both fields are maintained, new format is preferred
+             *   Automatic migration from old to new format on first load
+             * - v0.3.0: Remove this field completely, only use importPathEntries
+             * 
+             * TODO: Remove in v0.3.0
+             */
             @get:XCollection(style = XCollection.Style.v2)
             var importPaths: MutableList<String> = mutableListOf(),
+            
+            /**
+             * New format that supports enable/disable functionality for each path.
+             * This is the primary storage format from v0.2.0 onwards.
+             */
             @get:XCollection(style = XCollection.Style.v2)
             var importPathEntries: MutableList<ImportPathEntry> = mutableListOf()
     )

--- a/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsService.kt
+++ b/lsp/client/jetbrains/src/main/kotlin/com/github/mercari/grpcfederation/settings/ProjectSettingsService.kt
@@ -1,13 +1,25 @@
 package com.github.mercari.grpcfederation.settings
 
 import com.intellij.openapi.project.Project
+import com.intellij.util.xmlb.annotations.Tag
+import com.intellij.util.xmlb.annotations.XCollection
 
 interface ProjectSettingsService {
-    data class State(
-            var importPaths: List<String> = emptyList(),
+    @Tag("ImportPathEntry")
+    data class ImportPathEntry(
+            var path: String = "",
+            var enabled: Boolean = true
     )
 
-    var state: State
+    @Tag("GrpcFederationSettings")
+    data class State(
+            @get:XCollection(style = XCollection.Style.v2)
+            var importPaths: MutableList<String> = mutableListOf(),
+            @get:XCollection(style = XCollection.Style.v2)
+            var importPathEntries: MutableList<ImportPathEntry> = mutableListOf()
+    )
+
+    var currentState: State
 }
 
 val Project.projectSettings: ProjectSettingsService

--- a/lsp/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/lsp/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -18,5 +18,5 @@
                 displayName="gRPC Federation"
                 nonDefaultProject="true"/>
     </extensions>
-    <resource-bundle>messages.Bundle</resource-bundle>
+    <resource-bundle>messages.GrpcFederationBundle</resource-bundle>
 </idea-plugin>


### PR DESCRIPTION
## Summary
This PR significantly enhances the JetBrains plugin with improved UI, semantic tokens support, and bug fixes.

## Major Changes

### 1. Semantic Tokens Support for Enhanced Syntax Highlighting 🎨
- Implemented LSP semantic tokens support for proto files with gRPC Federation annotations
- Changed from `ProjectWideLspServerDescriptor` to `LspServerDescriptor` for proper semantic tokens support
- Added token type mappings for proper colorization of proto elements
- Override `shouldAskServerForSemanticTokens` to explicitly request tokens for proto files

### 2. Platform and Dependencies Upgrade ⬆️
- **IntelliJ Platform SDK**: Updated to 2024.3.3 (latest stable)
- **Gradle IntelliJ Platform Plugin**: Migrated from 1.x to 2.7.2 (latest)
- **Kotlin**: Updated to 2.1.0
- **JVM Toolchain**: Upgraded from Java 17 to Java 21 (recommended for 2024.3.3)
- **Gradle**: Updated to 8.10

### 3. Enhanced Import Path Configuration UI 🔧
- Replaced single text field with table-based UI for better path management
- Added explicit checkbox renderer and editor for the Enabled column
- Implemented Add, Remove, Move Up, and Move Down actions
- Added Browse button for folder selection dialog
- Added path validation functionality
- Variable expansion support for `~/` and `${PROJECT_ROOT}`
- Clear visual indication of enabled/disabled paths

### 4. Bug Fixes 🐛
- **Fixed diagnostics display issue**: HTML/XML entities in diagnostic messages are now properly escaped to prevent UI rendering issues
- **Fixed plugin display name**: Corrected from "grpc-federation" to "gRPC Federation"
- **Fixed checkbox display issue**: Added explicit renderer and editor for proper checkbox rendering in the Enabled column

### 5. Data Model Improvements
- Created `ImportPathTableModel` to manage import path entries
- Added `ImportPathEntry` data class with path and enabled fields
- Implemented automatic migration from old format to new format
- Backward compatibility maintained (reads both old and new formats)

### 6. Documentation Updates 📚
- Clarified IntelliJ IDEA Ultimate requirement in README
- Comprehensive CHANGELOG updates documenting all changes
- Added migration notes for settings format changes

## Breaking Changes
- Minimum IntelliJ version now requires 2024.3 (build 243)
- Java 21 is now required for development (runtime still uses bundled JBR)

## Migration Notes
- Existing import path configurations will be automatically migrated to the new format
- The old `importPaths` field will be deprecated in v0.3.0
- The plugin maintains backward compatibility by reading from both formats

## Test Plan
- [x] Install the plugin in IntelliJ IDEA Ultimate 2024.3+
- [x] Verify semantic tokens highlighting works for proto files
- [x] Open plugin settings (Settings > Tools > gRPC Federation)
- [x] Add new import paths using the Add button
- [x] Toggle enabled/disabled status using checkboxes
- [x] Reorder paths using Move Up/Down buttons
- [x] Validate paths using the Validate Paths button
- [x] Verify LSP server receives only enabled paths
- [x] Test diagnostics display with messages containing HTML tags
- [x] Verify plugin name displays as "gRPC Federation"
- [x] Confirm automatic migration of old settings format

### Before
<img width="1169" height="727" alt="jetbrains-plugin-grpc-federation-config_old" src="https://github.com/user-attachments/assets/67bb796a-2faa-4d5d-b277-ee65e8cad1ed" />

### After
<img width="1167" height="735" alt="jetbrains-plugin-grpc-federation-config" src="https://github.com/user-attachments/assets/7721329c-d7d1-432e-89f2-db7c28084ddb" />

🤖 Generated with [Claude Code](https://claude.ai/code)