### PR TITLE
fix(jetbrains-plugin): fix plugin descriptor error for JetBrains Marketplace publishing

### DIFF
--- a/.github/workflows/release-jetbrains.yml
+++ b/.github/workflows/release-jetbrains.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
       # Setup Gradle
       - uses: gradle/actions/setup-gradle@v3
         with:

--- a/lsp/client/jetbrains/build.gradle.kts
+++ b/lsp/client/jetbrains/build.gradle.kts
@@ -83,7 +83,7 @@ intellijPlatform {
         
         ideaVersion {
             sinceBuild = properties("pluginSinceBuild")
-            untilBuild = properties("pluginUntilBuild")
+            untilBuild = provider { null }
         }
     }
     

--- a/lsp/client/jetbrains/gradle.properties
+++ b/lsp/client/jetbrains/gradle.properties
@@ -8,13 +8,13 @@ pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
-# pluginUntilBuild is intentionally not set to allow the plugin to be compatible with future IDE versions.
+# pluginUntilBuild is not set to allow the plugin to be compatible with future IDE versions.
 # This is relatively safe because:
 # 1. This plugin uses stable LSP (Language Server Protocol) APIs which are unlikely to break
 # 2. The plugin has minimal IDE integration surface area
 # 3. Users can install and test on newer versions without waiting for plugin updates
 # If compatibility issues arise in future versions, we can add the restriction then.
-pluginUntilBuild = 
+# pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
## Summary
Fixes the "Invalid plugin descriptor" error when publishing the plugin to JetBrains Marketplace by properly configuring the `pluginUntilBuild` setting.

## Problem
When attempting to publish the plugin, the following error occurred:
```
Failed to upload plugin: Upload failed: Invalid plugin descriptor 'plugin.xml'. 
The <until-build> attribute () does not match the multi-part build number format
```

## Solution
- Set `untilBuild = provider { null }` in `build.gradle.kts` to explicitly remove the upper version bound
- Comment out `pluginUntilBuild` in `gradle.properties` instead of leaving it as an empty string

This configuration allows the plugin to be compatible with all future IntelliJ IDEA versions, which is appropriate for this LSP-based plugin that uses stable APIs.

## Test Plan
- [x] Build the plugin successfully
- [x] Verify plugin.xml does not contain an empty `until-build` attribute
- [ ] Successfully publish to JetBrains Marketplace

🤖 Generated with [Claude Code](https://claude.ai/code)