### PR TITLE
Fix wasm cache key mismatch between grpcfedctl and runtime

### DIFF
--- a/cmd/grpcfedctl/plugin.go
+++ b/cmd/grpcfedctl/plugin.go
@@ -43,7 +43,7 @@ func (c *PluginCacheCreateCommand) Execute(args []string) error {
 	}
 	if _, err := wazero.NewRuntimeWithConfig(
 		ctx,
-		wazero.NewRuntimeConfigCompiler().WithCompilationCache(cache),
+		wazero.NewRuntimeConfigCompiler().WithCompilationCache(cache).WithCloseOnContextDone(true),
 	).CompileModule(ctx, f); err != nil {
 		return fmt.Errorf("failed to compile wasm file: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fix an issue where wasm cache generated by `grpcfedctl plugin cache create` is not recognized by the runtime.

## Problem

wazero's cache key depends on `RuntimeConfig` options.

- **grpcfedctl**: `NewRuntimeConfigCompiler().WithCompilationCache(cache)`
- **runtime** (`grpc/federation/cel/plugin.go`): `runtimeCfg.WithDebugInfoEnabled(false).WithCloseOnContextDone(true)`

The presence of `.WithCloseOnContextDone(true)` changes the cache key. Since grpcfedctl did not include this option, the pre-generated cache is not recognized by the runtime, which then attempts to create a new cache file.

This causes pod startup failures in Kubernetes environments with `readOnlyRootFilesystem: true`:

open /path/to/plugin/wazero-v1.10.1-amd64-linux/xxx.tmp: read-only file system

## Solution

Add `.WithCloseOnContextDone(true)` to grpcfedctl's `RuntimeConfig` to generate cache keys that match the runtime.