### PR TITLE
feat(generator): add AdditionalCELOptions injection hook to service config

### DIFF
--- a/_examples/01_minimum/federation/federation_grpc_federation.pb.go
+++ b/_examples/01_minimum/federation/federation_grpc_federation.pb.go
@@ -37,6 +37,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -127,6 +140,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/02_simple/federation/federation_grpc_federation.pb.go
+++ b/_examples/02_simple/federation/federation_grpc_federation.pb.go
@@ -156,6 +156,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -287,6 +300,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAttrOption[Item_ItemType]("federation.Item.ItemType", Item_ItemType_attrMap))
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("federation.Item.Location.LocationType", Item_Location_LocationType_value, Item_Location_LocationType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
+++ b/_examples/03_custom_resolver/federation/federation_grpc_federation.pb.go
@@ -128,6 +128,19 @@ type FederationV2DevServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationV2DevServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -365,6 +378,7 @@ func NewFederationV2DevService(cfg FederationV2DevServiceConfig) (*FederationV2D
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("federation.v2dev.PostV2devType", PostV2DevType_value, PostV2DevType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.env", grpcfed.CELObjectType("grpc.federation.private.Env")))
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.var", grpcfed.CELObjectType("grpc.federation.private.ServiceVariable")))
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	var env FederationV2DevServiceEnv
 	if err := grpcfed.LoadEnv("", &env); err != nil {
 		return nil, err

--- a/_examples/04_timeout/federation/federation_grpc_federation.pb.go
+++ b/_examples/04_timeout/federation/federation_grpc_federation.pb.go
@@ -63,6 +63,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -167,6 +180,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.DeletePostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.GetPostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.UpdatePostResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/05_async/federation/federation_grpc_federation.pb.go
+++ b/_examples/05_async/federation/federation_grpc_federation.pb.go
@@ -161,6 +161,19 @@ type FederationService_Org_Federation_JArgument struct {
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
 type FederationServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -264,6 +277,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/06_alias/federation/federation_grpc_federation.pb.go
+++ b/_examples/06_alias/federation/federation_grpc_federation.pb.go
@@ -63,6 +63,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -182,6 +195,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.v2.ExtraType", post1.ExtraType_value, post1.ExtraType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.v2.PostContent.Category", post1.PostContent_Category_value, post1.PostContent_Category_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.v2.PostDataType", post1.PostDataType_value, post1.PostDataType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/07_autobind/federation/federation_grpc_federation.pb.go
+++ b/_examples/07_autobind/federation/federation_grpc_federation.pb.go
@@ -63,6 +63,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -163,6 +176,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.GetPostResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/08_literal/federation/federation_grpc_federation.pb.go
+++ b/_examples/08_literal/federation/federation_grpc_federation.pb.go
@@ -41,6 +41,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -137,6 +150,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "content.GetContentResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("content.ContentType", content.ContentType_value, content.ContentType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.federation.ContentType", ContentType_value, ContentType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
+++ b/_examples/09_multi_user/federation/federation_grpc_federation.pb.go
@@ -80,6 +80,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -199,6 +212,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "user.GetUserResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/10_oneof/federation/federation_grpc_federation.pb.go
+++ b/_examples/10_oneof/federation/federation_grpc_federation.pb.go
@@ -113,6 +113,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -244,6 +257,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "user.GetUserResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.federation.UserType", UserType_value, UserType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("user.UserType", user.UserType_value, user.UserType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/federation_grpc_federation.pb.go
@@ -101,6 +101,19 @@ type FederationService_Federation_UserArgument struct {
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
 type FederationServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -249,6 +262,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("federation.MyFavoriteType", MyFavoriteType_value, MyFavoriteType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.env", grpcfed.CELObjectType("grpc.federation.private.Env")))
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.var", grpcfed.CELObjectType("grpc.federation.private.ServiceVariable")))
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	var env FederationServiceEnv
 	if err := grpcfed.LoadEnv("", &env); err != nil {
 		return nil, err
@@ -1504,6 +1518,19 @@ type PrivateService_Federation_UserArgument struct {
 
 // PrivateServiceConfig configuration required to initialize the service that use GRPC Federation.
 type PrivateServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -1656,6 +1683,7 @@ func NewPrivateService(cfg PrivateServiceConfig) (*PrivateService, error) {
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("federation.MyFavoriteType", MyFavoriteType_value, MyFavoriteType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.env", grpcfed.CELObjectType("grpc.federation.private.Env")))
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.var", grpcfed.CELObjectType("grpc.federation.private.ServiceVariable")))
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	var env PrivateServiceEnv
 	if err := grpcfed.LoadEnv("", &env); err != nil {
 		return nil, err
@@ -2968,6 +2996,19 @@ type DebugService_Federation_UserArgument struct {
 
 // DebugServiceConfig configuration required to initialize the service that use GRPC Federation.
 type DebugServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -3049,6 +3090,7 @@ func NewDebugService(cfg DebugServiceConfig) (*DebugService, error) {
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("favorite.FavoriteType", favorite.FavoriteType_value, favorite.FavoriteType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("federation.MyFavoriteType", MyFavoriteType_value, MyFavoriteType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &DebugService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/11_multi_service/federation/other_grpc_federation.pb.go
+++ b/_examples/11_multi_service/federation/other_grpc_federation.pb.go
@@ -80,6 +80,19 @@ type OtherServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver OtherServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -180,6 +193,7 @@ func NewOtherService(cfg OtherServiceConfig) (*OtherService, error) {
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("favorite.FavoriteType", favorite.FavoriteType_value, favorite.FavoriteType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("federation.MyFavoriteType", MyFavoriteType_value, MyFavoriteType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &OtherService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/12_validation/federation/federation_grpc_federation.pb.go
+++ b/_examples/12_validation/federation/federation_grpc_federation.pb.go
@@ -71,6 +71,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -168,6 +181,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/13_map/federation/federation_grpc_federation.pb.go
+++ b/_examples/13_map/federation/federation_grpc_federation.pb.go
@@ -81,6 +81,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -197,6 +210,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "user.GetUserResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.federation.Item.ItemType", Item_ItemType_value, Item_ItemType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/14_condition/federation/federation_grpc_federation.pb.go
+++ b/_examples/14_condition/federation/federation_grpc_federation.pb.go
@@ -65,6 +65,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -165,6 +178,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.GetPostResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/15_cel_plugin/federation/federation_grpc_federation.pb.go
@@ -68,6 +68,19 @@ type FederationServiceConfig struct {
 	// you must write a plugin and output WebAssembly.
 	// In this field, configure to load wasm with the path to the WebAssembly file and the sha256 value.
 	CELPlugin *FederationServiceCELPluginConfig
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -240,6 +253,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		celPlugins = append(celPlugins, plugin)
 		celEnvOpts = append(celEnvOpts, grpcfed.CELLib(plugin))
 	}
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
+++ b/_examples/16_code_gen_plugin/federation/federation_grpc_federation.pb.go
@@ -37,6 +37,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -127,6 +140,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
+++ b/_examples/17_error_handler/federation/federation_grpc_federation.pb.go
@@ -100,6 +100,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -209,6 +222,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.GetPostResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/18_load/federation/federation_grpc_federation.pb.go
+++ b/_examples/18_load/federation/federation_grpc_federation.pb.go
@@ -39,6 +39,19 @@ type FederationServiceConfig struct {
 	// you must write a plugin and output WebAssembly.
 	// In this field, configure to load wasm with the path to the WebAssembly file and the sha256 value.
 	CELPlugin *FederationServiceCELPluginConfig
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -157,6 +170,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		celPlugins = append(celPlugins, plugin)
 		celEnvOpts = append(celEnvOpts, grpcfed.CELLib(plugin))
 	}
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/19_retry/federation/federation_grpc_federation.pb.go
+++ b/_examples/19_retry/federation/federation_grpc_federation.pb.go
@@ -49,6 +49,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -146,6 +159,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.GetPostResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/20_callopt/federation/federation_grpc_federation.pb.go
+++ b/_examples/20_callopt/federation/federation_grpc_federation.pb.go
@@ -45,6 +45,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -139,6 +152,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "post.GetPostResponse")...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/21_wasm_net/federation/federation_grpc_federation.pb.go
+++ b/_examples/21_wasm_net/federation/federation_grpc_federation.pb.go
@@ -43,6 +43,19 @@ type FederationServiceConfig struct {
 	// you must write a plugin and output WebAssembly.
 	// In this field, configure to load wasm with the path to the WebAssembly file and the sha256 value.
 	CELPlugin *FederationServiceCELPluginConfig
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -189,6 +202,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 		celPlugins = append(celPlugins, plugin)
 		celEnvOpts = append(celEnvOpts, grpcfed.CELLib(plugin))
 	}
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/_examples/22_switch/federation/federation_grpc_federation.pb.go
+++ b/_examples/22_switch/federation/federation_grpc_federation.pb.go
@@ -37,6 +37,19 @@ type FederationService_Org_Federation_GetPostResponseArgument struct {
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
 type FederationServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -164,6 +177,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.env", grpcfed.CELObjectType("grpc.federation.private.Env")))
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.var", grpcfed.CELObjectType("grpc.federation.private.ServiceVariable")))
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	var env FederationServiceEnv
 	if err := grpcfed.LoadEnv("", &env); err != nil {
 		return nil, err

--- a/generator/templates/server.go.tmpl
+++ b/generator/templates/server.go.tmpl
@@ -99,6 +99,19 @@ type {{ $serviceName }}Config struct {
 	// In this field, configure to load wasm with the path to the WebAssembly file and the sha256 value.
 	CELPlugin *{{ $serviceName }}CELPluginConfig
 	{{- end }}
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -397,6 +410,7 @@ func New{{ $serviceName }}(cfg {{ $serviceName }}Config) (*{{ $serviceName }}, e
 		celEnvOpts = append(celEnvOpts, grpcfed.CELLib(plugin))
 	}
 	{{- end }}
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	{{- if $env }}
 	var env {{ $serviceName }}Env
 	if err := grpcfed.LoadEnv("", &env); err != nil {

--- a/generator/testdata/expected_alias.go
+++ b/generator/testdata/expected_alias.go
@@ -56,6 +56,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -161,6 +174,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.federation.PostType", PostType_value, PostType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostContent.Category", post.PostContent_Category_value, post.PostContent_Category_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostDataType", post.PostDataType_value, post.PostDataType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_alias_multifile.go
+++ b/generator/testdata/expected_alias_multifile.go
@@ -56,6 +56,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -172,6 +185,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.v2.ExtraType", post1.ExtraType_value, post1.ExtraType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.v2.PostContent.Category", post1.PostContent_Category_value, post1.PostContent_Category_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.v2.PostDataType", post1.PostDataType_value, post1.PostDataType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_async.go
+++ b/generator/testdata/expected_async.go
@@ -161,6 +161,19 @@ type FederationService_Org_Federation_JArgument struct {
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
 type FederationServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -264,6 +277,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_autobind.go
+++ b/generator/testdata/expected_autobind.go
@@ -63,6 +63,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -164,6 +177,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.post.GetPostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_condition.go
+++ b/generator/testdata/expected_condition.go
@@ -65,6 +65,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -166,6 +179,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.post.GetPostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_create_post.go
+++ b/generator/testdata/expected_create_post.go
@@ -69,6 +69,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -179,6 +192,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.post.UpdatePostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.federation.PostType", PostType_value, PostType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_custom_resolver.go
+++ b/generator/testdata/expected_custom_resolver.go
@@ -83,6 +83,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -231,6 +244,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.UserType", user.UserType_value, user.UserType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_error_handler.go
+++ b/generator/testdata/expected_error_handler.go
@@ -75,6 +75,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -179,6 +192,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.post.GetPostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_inline_env.go
+++ b/generator/testdata/expected_inline_env.go
@@ -24,6 +24,19 @@ var (
 
 // InlineEnvServiceConfig configuration required to initialize the service that use GRPC Federation.
 type InlineEnvServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -158,6 +171,7 @@ func NewInlineEnvService(cfg InlineEnvServiceConfig) (*InlineEnvService, error) 
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.env", grpcfed.CELObjectType("grpc.federation.private.Env")))
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.var", grpcfed.CELObjectType("grpc.federation.private.ServiceVariable")))
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	var env InlineEnvServiceEnv
 	if err := grpcfed.LoadEnv("", &env); err != nil {
 		return nil, err

--- a/generator/testdata/expected_map.go
+++ b/generator/testdata/expected_map.go
@@ -83,6 +83,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -214,6 +227,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.UserType", user.UserType_value, user.UserType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_minimum.go
+++ b/generator/testdata/expected_minimum.go
@@ -38,6 +38,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -130,6 +143,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.federation.PostType", PostType_value, PostType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_multi_user.go
+++ b/generator/testdata/expected_multi_user.go
@@ -80,6 +80,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -201,6 +214,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.user.GetUserResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.UserType", user.UserType_value, user.UserType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_oneof.go
+++ b/generator/testdata/expected_oneof.go
@@ -72,6 +72,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -181,6 +194,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.user.GetUserResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.UserType", user.UserType_value, user.UserType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_ref_env.go
+++ b/generator/testdata/expected_ref_env.go
@@ -33,6 +33,19 @@ type RefEnvService_Org_Federation_ConstantArgument struct {
 
 // RefEnvServiceConfig configuration required to initialize the service that use GRPC Federation.
 type RefEnvServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -164,6 +177,7 @@ func NewRefEnvService(cfg RefEnvServiceConfig) (*RefEnvService, error) {
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.env", grpcfed.CELObjectType("grpc.federation.private.Env")))
 	celEnvOpts = append(celEnvOpts, grpcfed.NewCELVariable("grpc.federation.var", grpcfed.CELObjectType("grpc.federation.private.ServiceVariable")))
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	var env RefEnvServiceEnv
 	if err := grpcfed.LoadEnv("", &env); err != nil {
 		return nil, err

--- a/generator/testdata/expected_resolver_overlaps.go
+++ b/generator/testdata/expected_resolver_overlaps.go
@@ -62,6 +62,19 @@ type FederationServiceConfig struct {
 	// Client provides a factory that creates the gRPC Client needed to invoke methods of the gRPC Service on which the Federation Service depends.
 	// If this interface is not provided, an error is returned during initialization.
 	Client FederationServiceClientFactory // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -164,6 +177,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.GRPCErrorAccessorOptions(celTypeHelper, "org.post.GetPostResponse")...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostContent.Category", post.PostContent_Category_value, post.PostContent_Category_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostDataType", post.PostDataType_value, post.PostDataType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_simple_aggregation.go
+++ b/generator/testdata/expected_simple_aggregation.go
@@ -116,6 +116,19 @@ type FederationServiceConfig struct {
 	// Resolver provides an interface to directly implement message resolver and field resolver not defined in Protocol Buffers.
 	// If this interface is not provided, an error is returned during initialization.
 	Resolver FederationServiceResolver // required
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -263,6 +276,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.post.PostType", post.PostType_value, post.PostType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.Item.ItemType", user.Item_ItemType_value, user.Item_ItemType_name)...)
 	celEnvOpts = append(celEnvOpts, grpcfed.EnumAccessorOptions("org.user.UserType", user.UserType_value, user.UserType_name)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_switch.go
+++ b/generator/testdata/expected_switch.go
@@ -37,6 +37,19 @@ type FederationService_Org_Federation_GetPostResponseArgument struct {
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
 type FederationServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -114,6 +127,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/generator/testdata/expected_validation.go
+++ b/generator/testdata/expected_validation.go
@@ -56,6 +56,19 @@ type FederationService_Org_Federation_PostArgument struct {
 
 // FederationServiceConfig configuration required to initialize the service that use GRPC Federation.
 type FederationServiceConfig struct {
+	// AdditionalCELOptions allows the caller to inject extra CEL environment options
+	// (for example, native Go cel.Function bindings) after the framework-provided
+	// options and CELPlugin EnvOpts have been registered.
+	//
+	// Because cel-go's FunctionDecl.AddOverload replaces the binding when an overload
+	// with the same overload ID and matching signature is re-declared, callers can
+	// use this hook to override functions already registered by a CEL WASM plugin
+	// with native Go implementations. This is useful when a plugin-registered
+	// function is purely in-memory (e.g. JWT parsing) and the per-process mutex
+	// serialization in CELPluginInstance.Call is undesirable.
+	//
+	// Default zero value (nil) is a no-op and preserves the existing behavior.
+	AdditionalCELOptions []grpcfed.CELEnvOption
 	// ErrorHandler Federation Service often needs to convert errors received from downstream services.
 	// If an error occurs during method execution in the Federation Service, this error handler is called and the returned error is treated as a final error.
 	ErrorHandler grpcfed.ErrorHandler
@@ -137,6 +150,7 @@ func NewFederationService(cfg FederationServiceConfig) (*FederationService, erro
 	celTypeHelper := grpcfed.NewCELTypeHelper("org.federation", celTypeHelperFieldMap)
 	var celEnvOpts []grpcfed.CELEnvOption
 	celEnvOpts = append(celEnvOpts, grpcfed.NewDefaultEnvOptions(celTypeHelper)...)
+	celEnvOpts = append(celEnvOpts, cfg.AdditionalCELOptions...)
 	svc := &FederationService{
 		cfg:             cfg,
 		logger:          logger,

--- a/grpc/federation/additional_cel_options_test.go
+++ b/grpc/federation/additional_cel_options_test.go
@@ -1,0 +1,153 @@
+package federation_test
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	grpcfed "github.com/mercari/grpc-federation/grpc/federation"
+)
+
+// TestAdditionalCELOptions_OverridesBindingByOverloadID verifies the design
+// assumption underlying the AdditionalCELOptions hook on the generated service
+// config: when a CEL EnvOption registers a cel.Function with the same name and
+// the same overload ID and matching signature as a previously registered
+// function, the later binding replaces the earlier one.
+//
+// In the generator, AdditionalCELOptions are appended to celEnvOpts AFTER any
+// CEL plugin (WASM) bindings, so callers can inject native Go bindings to
+// override plugin-registered functions for performance-critical CEL functions
+// (e.g. pure in-memory operations that should not pay the WASM dispatch +
+// per-process mutex serialization cost in CELPluginInstance.Call).
+//
+// This test exercises that semantics with cel-go directly so that we have a
+// regression guard independent of the WASM plugin runtime.
+func TestAdditionalCELOptions_OverridesBindingByOverloadID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fnName     = "example_fn"
+		overloadID = "example_fn_string"
+	)
+
+	// First binding ("plugin"): returns "from_plugin".
+	pluginOpt := cel.Function(fnName,
+		cel.Overload(overloadID, []*cel.Type{}, cel.StringType,
+			cel.FunctionBinding(func(_ ...ref.Val) ref.Val {
+				return types.String("from_plugin")
+			}),
+		),
+	)
+
+	// Second binding ("native override"): same overload ID + signature, returns "from_native".
+	nativeOpt := cel.Function(fnName,
+		cel.Overload(overloadID, []*cel.Type{}, cel.StringType,
+			cel.FunctionBinding(func(_ ...ref.Val) ref.Val {
+				return types.String("from_native")
+			}),
+		),
+	)
+
+	// Build env in the same order generator emits: plugin first, then AdditionalCELOptions.
+	envOpts := []grpcfed.CELEnvOption{pluginOpt, nativeOpt}
+	env, err := cel.NewEnv(envOpts...)
+	if err != nil {
+		t.Fatalf("failed to build cel env: %v", err)
+	}
+
+	ast, iss := env.Compile(fnName + "()")
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("compile failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("program failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]any{})
+	if err != nil {
+		t.Fatalf("eval failed: %v", err)
+	}
+	got, ok := out.Value().(string)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", out.Value())
+	}
+	if got != "from_native" {
+		t.Fatalf("expected later AddOverload binding to win (from_native) but got %q", got)
+	}
+}
+
+// TestAdditionalCELOptions_AppendOrderEquivalence verifies that appending
+// AdditionalCELOptions to a pre-built celEnvOpts slice (the operation the
+// generator emits in NewXxxService) preserves the override-by-later-binding
+// behavior relied on by callers.
+func TestAdditionalCELOptions_AppendOrderEquivalence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		fnName     = "example_fn2"
+		overloadID = "example_fn2_string"
+	)
+	pluginOpt := cel.Function(fnName,
+		cel.Overload(overloadID, []*cel.Type{}, cel.StringType,
+			cel.FunctionBinding(func(_ ...ref.Val) ref.Val { return types.String("plugin") }),
+		),
+	)
+	nativeOpt := cel.Function(fnName,
+		cel.Overload(overloadID, []*cel.Type{}, cel.StringType,
+			cel.FunctionBinding(func(_ ...ref.Val) ref.Val { return types.String("native") }),
+		),
+	)
+
+	// Mimic generator: build base celEnvOpts, then append AdditionalCELOptions.
+	var celEnvOpts []grpcfed.CELEnvOption
+	celEnvOpts = append(celEnvOpts, pluginOpt)
+	additional := []grpcfed.CELEnvOption{nativeOpt}
+	celEnvOpts = append(celEnvOpts, additional...)
+
+	env, err := cel.NewEnv(celEnvOpts...)
+	if err != nil {
+		t.Fatalf("failed to build cel env: %v", err)
+	}
+	ast, iss := env.Compile(fnName + "()")
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("compile failed: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("program failed: %v", err)
+	}
+	out, _, err := prg.Eval(map[string]any{})
+	if err != nil {
+		t.Fatalf("eval failed: %v", err)
+	}
+	if got := out.Value().(string); got != "native" {
+		t.Fatalf("expected appended option to override base binding (native), got %q", got)
+	}
+
+	// Also verify the no-op case: nil AdditionalCELOptions preserves base binding.
+	var baseOnly []grpcfed.CELEnvOption
+	baseOnly = append(baseOnly, pluginOpt)
+	var nilAdditional []grpcfed.CELEnvOption
+	baseOnly = append(baseOnly, nilAdditional...)
+	env2, err := cel.NewEnv(baseOnly...)
+	if err != nil {
+		t.Fatalf("failed to build base-only env: %v", err)
+	}
+	ast2, iss := env2.Compile(fnName + "()")
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("compile (base-only) failed: %v", iss.Err())
+	}
+	prg2, err := env2.Program(ast2)
+	if err != nil {
+		t.Fatalf("program (base-only) failed: %v", err)
+	}
+	out2, _, err := prg2.Eval(map[string]any{})
+	if err != nil {
+		t.Fatalf("eval (base-only) failed: %v", err)
+	}
+	if got := out2.Value().(string); got != "plugin" {
+		t.Fatalf("expected base binding (plugin) when AdditionalCELOptions is nil, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an `AdditionalCELOptions []grpcfed.CELEnvOption` field to each generated `XxxServiceConfig` and emits an append after plugin EnvOpts in `NewXxxService`. This allows consumers to inject native Go CEL bindings to override or supplement WASM-plugin-registered functions.

Refs #366

## Motivation

A downstream gRPC service using grpc-federation experienced a production outage on 2026-04-27 that traced back to per-process mutex serialization in `CELPluginInstance.Call` (`grpc/federation/cel/plugin.go`). See #366 for the full problem statement.

Specific mechanism:

- A response message fanned out to ~11 internal data submessages, 7+ of which call a single CEL function (a pure in-memory JWT parse with no I/O — i.e., a function that conceptually does not need WASM isolation).
- This CEL function must currently be registered as a WASM plugin → every invocation acquires `i.mu.Lock()` on the single active `CELPluginInstance`.
- Under load, the mutex queue grew to 14–34 s wait, exceeding the 25 s upstream gateway deadline.
- Goroutines parked at `i.mu.Lock()` are not context-aware, so `ctx.Done()` does not free them and resources accumulated until OOM.

The fundamental issue is that the framework offers no path to register a CEL function as native Go code, so even pure-CPU functions pay the WASM dispatch + mutex-serialization cost.

## Approach

Option 2 from the design exploration in #366 (chosen for backward compatibility):

- Add `AdditionalCELOptions []grpcfed.CELEnvOption` field to each generated `XxxServiceConfig`.
- In `NewXxxService`, append `cfg.AdditionalCELOptions...` to the assembled `celEnvOpts` slice **after** the WASM plugin EnvOpts.
- Caller can pass a `cel.Function(...)` with the same overload ID + signature; per cel-go's `FunctionDecl.AddOverload` semantics (cel-go `common/decls/decls.go:266-291`), this replaces the binding.

## Backward compatibility

- Default zero-value (`nil` slice) is functionally equivalent to current behavior.
- All existing generated code remains valid (new field is ignored if unset).
- No breaking change to public API.

## Alternatives considered (and rejected for this PR)

- **New `NATIVE` plugin type** — Extending the proto schema with a new plugin type. Rejected as more invasive, higher migration cost across consumers, and proto-schema breaking.
- **Replacing `sync.Mutex` with context-aware semaphore in `CELPluginInstance.Call`** — Tracked in #366 as a related but orthogonal change.

## Tests

- All existing `generator/testdata/expected_*.go` golden files updated to include the new field (zero-value).
- All `_examples/*/federation/*_grpc_federation.pb.go` regenerated; example tests (`make test/examples`) all pass.
- New test `grpc/federation/additional_cel_options_test.go` validates two scenarios using cel-go directly (no WASM dependency):
  1. `cel.Function` with the same overload ID + signature, registered later, **replaces** the earlier binding.
  2. Appending `AdditionalCELOptions` to a base `celEnvOpts` slice (mirroring the generator's emission pattern) preserves the override behavior; passing nil is a no-op.

`make lint` is clean; `go test ./...` passes for both the framework and all examples.

## Notes

This is a Draft PR for design discussion. Happy to revise the approach (e.g. a more typed config interface, a different emission point, or hiding the field behind a setter) based on maintainer preference.

Signed off via DCO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)