### PR TITLE
feat(cel): make CELPluginInstance mutex context-aware

### DIFF
--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -414,7 +415,11 @@ func (p *CELPlugin) createInstance(ctx context.Context) (*CELPluginInstance, err
 		gcQueue:          make(chan struct{}, gcQueueLength),
 		gcErrCh:          make(chan error, 1),
 		instanceModErrCh: make(chan error, 1),
-		cancelFn:         cancel,
+		// sem serializes invocations into the WASM instance with capacity 1
+		// (equivalent to sync.Mutex), but Acquire is context-aware so that
+		// upstream cancellation can free parked goroutines.
+		sem:      semaphore.NewWeighted(1),
+		cancelFn: cancel,
 	}
 	instance.id = fmt.Sprintf("%s-%p", p.cfg.Name, instance)
 
@@ -566,9 +571,15 @@ type CELPluginInstance struct {
 	instanceModErr   error
 	gcErrCh          chan error
 	closed           bool
-	mu               sync.Mutex
-	gcQueue          chan struct{}
-	cancelFn         context.CancelFunc
+	// sem is a capacity-1 weighted semaphore that serializes calls into the
+	// underlying WASM instance, replacing what was previously a sync.Mutex.
+	// Acquire(ctx, 1) is context-aware: when the caller's context is canceled
+	// while waiting, Acquire returns ctx.Err() and the goroutine (along with
+	// its stack, function arguments, and trace span) can be released, instead
+	// of remaining parked indefinitely as it would on sync.Mutex.Lock().
+	sem      *semaphore.Weighted
+	gcQueue  chan struct{}
+	cancelFn context.CancelFunc
 }
 
 const PluginProtocolVersion = 2
@@ -589,8 +600,12 @@ func (i *CELPluginInstance) ValidatePlugin(ctx context.Context) error {
 	ctx, span := trace.Trace(ctx, "ValidatePlugin")
 	defer span.End()
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	if err := i.sem.Acquire(ctx, 1); err != nil {
+		// Acquire returns ctx.Err() on cancellation and leaves the semaphore
+		// unchanged, so Release must NOT be called on this path.
+		return err
+	}
+	defer i.sem.Release(1)
 
 	if err := i.write(ctx, []byte(VersionCommand)); err != nil {
 		return fmt.Errorf("failed to send cel protocol version command: %w", err)
@@ -645,8 +660,14 @@ func (i *CELPluginInstance) Close() error {
 		return nil
 	}
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	// Close is called during shutdown and must wait for any in-flight call to
+	// complete before tearing down resources. Acquire with a Background ctx
+	// blocks until success and never returns an error, preserving the
+	// previous sync.Mutex.Lock() semantic on this path.
+	if err := i.sem.Acquire(context.Background(), 1); err != nil {
+		return err
+	}
+	defer i.sem.Release(1)
 
 	return i.close()
 }
@@ -697,8 +718,22 @@ func (i *CELPluginInstance) startGC(ctx context.Context) error {
 	ctx, span := trace.Trace(ctx, "github.com/mercari/grpc-federation.CELPluginInstance.startGC")
 	defer span.End()
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	// GC is not bound to any user request context. Use a fresh
+	// Background-derived ctx with gcWaitTimeout so that if the semaphore is
+	// held by an in-flight Call for longer than gcWaitTimeout, we abandon
+	// this GC attempt rather than blocking the GC goroutine forever. The
+	// previous sync.Mutex.Lock() could not time out, so this is also a
+	// strict improvement on top of context-awareness.
+	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), gcWaitTimeout)
+	defer acquireCancel()
+	if err := i.sem.Acquire(acquireCtx, 1); err != nil {
+		// Acquire timed out (or the ctx was canceled). Skip this GC tick;
+		// the next enqueueGC tick will retry. Do NOT call Release here:
+		// semaphore is unchanged on Acquire failure.
+		log.Logger(ctx).WarnContext(ctx, fmt.Sprintf("grpc-federation: skipping GC because instance lock could not be acquired within %s: %v", gcWaitTimeout, err))
+		return nil
+	}
+	defer i.sem.Release(1)
 
 	if i.closed {
 		return nil
@@ -740,8 +775,17 @@ func (i *CELPluginInstance) Call(ctx context.Context, fn *CELFunction, md metada
 	ctx, span := trace.Trace(ctx, "Call")
 	defer span.End()
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	// Acquire is context-aware. If ctx is canceled (upstream gateway timeout
+	// or client disconnect) while waiting for the in-flight call to finish,
+	// Acquire returns ctx.Err() and this goroutine — along with its stack,
+	// arguments, and the trace span opened above — can be released, instead
+	// of staying parked on a non-cancellable sync.Mutex.Lock().
+	if err := i.sem.Acquire(ctx, 1); err != nil {
+		// Per semaphore.Weighted docs: "On failure, returns ctx.Err() and
+		// leaves the semaphore unchanged." Do NOT call Release on this path.
+		return nil, err
+	}
+	defer i.sem.Release(1)
 
 	if err := i.sendRequest(ctx, fn, md, args...); err != nil {
 		return nil, err

--- a/grpc/federation/cel/plugin_test.go
+++ b/grpc/federation/cel/plugin_test.go
@@ -5,12 +5,17 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestPlugin(t *testing.T) {
@@ -61,5 +66,197 @@ func TestPlugin(t *testing.T) {
 	}
 	if int(iv) != 10 {
 		t.Fatalf("failed to get response value: %v", iv)
+	}
+}
+
+// newInstanceForSemaphoreTest constructs a minimally-initialized
+// CELPluginInstance suitable for exercising the semaphore-acquisition path of
+// Call/ValidatePlugin without spinning up a real WASM module. It only
+// initializes fields that the methods touch before sem.Acquire returns.
+func newInstanceForSemaphoreTest() *CELPluginInstance {
+	return &CELPluginInstance{
+		name:             "sem-test",
+		sem:              semaphore.NewWeighted(1),
+		reqCh:            make(chan []byte, 1),
+		resCh:            make(chan []byte),
+		gcErrCh:          make(chan error, 1),
+		instanceModErrCh: make(chan error, 1),
+		gcQueue:          make(chan struct{}, 1),
+	}
+}
+
+// TestCallReleasesOnCtxCancel verifies that when a goroutine is blocked on
+// Call() waiting for the semaphore (i.e. another call holds the instance),
+// canceling that goroutine's ctx unblocks it promptly with ctx.Err(), instead
+// of leaking the goroutine + arguments + span until the previous holder
+// finally returns.
+//
+// Before this change, Call() acquired sync.Mutex.Lock() which is not
+// context-aware, so a parked goroutine could not be woken by ctx.Done().
+func TestCallReleasesOnCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	inst := newInstanceForSemaphoreTest()
+
+	// Simulate an in-flight call holding the instance lock.
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type result struct {
+		val ref.Val
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		fn := &CELFunction{Name: "f", ID: "f", Return: types.IntType}
+		v, err := inst.Call(ctx, fn, metadata.MD{})
+		done <- result{val: v, err: err}
+	}()
+
+	// Give the goroutine a moment to actually park on Acquire.
+	time.Sleep(20 * time.Millisecond)
+
+	select {
+	case <-done:
+		t.Fatal("Call returned before ctx cancel; expected it to be parked on the semaphore")
+	default:
+	}
+
+	cancel()
+
+	select {
+	case r := <-done:
+		if !errors.Is(r.err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", r.err)
+		}
+		if r.val != nil {
+			t.Fatalf("expected nil value on cancel, got %v", r.val)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call did not return within 2s after ctx cancel; semaphore is not context-aware")
+	}
+}
+
+// TestCallReleasesOnCtxDeadline verifies deadline propagation: when the
+// caller's ctx has a deadline, Call() blocked on the semaphore must return
+// context.DeadlineExceeded shortly after the deadline.
+func TestCallReleasesOnCtxDeadline(t *testing.T) {
+	t.Parallel()
+
+	inst := newInstanceForSemaphoreTest()
+
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	const deadline = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		fn := &CELFunction{Name: "f", ID: "f", Return: types.IntType}
+		_, err := inst.Call(ctx, fn, metadata.MD{})
+		done <- result{err: err}
+	}()
+
+	select {
+	case r := <-done:
+		elapsed := time.Since(start)
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Fatalf("expected context.DeadlineExceeded, got %v", r.err)
+		}
+		// Sanity check: should be roughly the deadline, not a hang.
+		if elapsed > 2*time.Second {
+			t.Fatalf("Call returned only after %v, expected ~%v", elapsed, deadline)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call did not return within 2s after deadline; semaphore is not context-aware")
+	}
+}
+
+// TestValidatePluginReleasesOnCtxCancel verifies the same context-aware
+// behavior on ValidatePlugin's semaphore acquisition path.
+func TestValidatePluginReleasesOnCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	inst := newInstanceForSemaphoreTest()
+
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- inst.ValidatePlugin(ctx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidatePlugin did not return within 2s after ctx cancel")
+	}
+}
+
+// TestStartGCSkipsOnAcquireTimeout verifies that the GC code path skips when
+// the semaphore is held by an in-flight call for longer than gcWaitTimeout.
+// This preserves the pre-existing "skip on contention" behavior while making
+// the wait bounded (it was previously unbounded under sync.Mutex).
+func TestStartGCSkipsOnAcquireTimeout(t *testing.T) {
+	// Lower gcWaitTimeout for the duration of this test so it runs quickly.
+	t.Cleanup(func() { gcWaitTimeout = 10 * time.Second })
+	gcWaitTimeout = 50 * time.Millisecond
+
+	inst := newInstanceForSemaphoreTest()
+
+	// Simulate a long-running call holding the semaphore.
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- inst.startGC(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("expected nil error on GC skip, got %v", err)
+		}
+		// startGC must have given up around gcWaitTimeout, not blocked forever.
+		if elapsed > 1*time.Second {
+			t.Fatalf("startGC returned only after %v, expected ~%v", elapsed, gcWaitTimeout)
+		}
+		// And it must NOT have called cancelFn or pushed to gcErrCh in the
+		// skip path (those are reserved for the GC-hang path).
+		select {
+		case <-inst.gcErrCh:
+			t.Fatal("gcErrCh should not receive a value when GC is skipped on Acquire timeout")
+		default:
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startGC did not return within 2s; expected skip after Acquire timeout")
 	}
 }


### PR DESCRIPTION
## Summary

Replaces `sync.Mutex` with `golang.org/x/sync/semaphore.Weighted(1)` on `CELPluginInstance`. Lock/Unlock pairs become `Acquire(ctx, 1)` / `Release(1)`, making the serialization point context-aware so upstream `ctx.Done()` actually unblocks parked goroutines.

Refs #366

## Motivation

The current `sync.Mutex` in `CELPluginInstance.Call` (`grpc/federation/cel/plugin.go`) serializes all WASM CEL plugin invocations per process. `sync.Mutex.Lock()` is not context-aware: a goroutine parked on it cannot be woken by `ctx.Done()`. Under load, this means:

- Request-scoped goroutines pile up at the lock
- Each parked goroutine holds its stack, function arguments (token bytes, metadata maps, CEL `ref.Val` slices), and the trace span (opened before the lock at `trace.Trace(ctx, "Call")`)
- Upstream cancellation (gateway timeout, client disconnect) cannot free them
- Memory pressure grows linearly with queue depth → OOM

A downstream service hit this in production on 2026-04-27. See #366 for the full incident background.

## Approach

Behavior preserved:
- Capacity-1 semaphore = same serialization as before
- `gcWaitTimeout = 10s` skip-on-timeout behavior preserved in the GC path (uses `context.WithTimeout(context.Background(), gcWaitTimeout)`)
- Backup-instance switchover semantics unchanged
- `Close()` uses `context.Background()` for Acquire so shutdown still waits for any in-flight call (same as the previous `sync.Mutex.Lock()` semantic on this path)

What changes:
- `Call` returns `ctx.Err()` immediately when cancelled while waiting for the instance, freeing the goroutine + closure + span resources
- `ValidatePlugin` is also context-aware now (it goes through the same lock)
- `startGC` bounds its wait at `gcWaitTimeout`: if a call is in flight longer than that, GC skips this tick (the next `enqueueGC` retries)
- `Release(1)` is only called on the success path of `Acquire` (per `golang.org/x/sync/semaphore` docs: "On failure, returns ctx.Err() and leaves the semaphore unchanged")

## Tests

- Existing tests: pass (`go test -race ./...`, including the WASM-based `TestPlugin` and `_examples/15_cel_plugin`, `_examples/21_wasm_net`)
- New tests in `grpc/federation/cel/plugin_test.go`:
  - `TestCallReleasesOnCtxCancel`: a Call blocked on the semaphore returns `context.Canceled` within 2s of `cancel()`
  - `TestCallReleasesOnCtxDeadline`: deadline propagation via `context.WithTimeout(50ms)`
  - `TestValidatePluginReleasesOnCtxCancel`: same context-aware behavior on the validation path
  - `TestStartGCSkipsOnAcquireTimeout`: confirms the GC code skips (returns `nil`) when it cannot acquire within `gcWaitTimeout`, without forcing the cancel/backup-switchover path

## Backward compatibility

- Public API unchanged
- Existing user code using `Call(ctx, ...)` sees identical behavior, except cancellation now actually works
- No proto / config schema change
- `golang.org/x/sync` is already an indirect dependency (`go.mod` v0.14.0); this PR does not change `go.mod` / `go.sum`

## Relationship to #367 and #366

- This PR addresses one of the two issues raised in #366 (the mutex-not-context-aware property)
- It is independent of #367 (`AdditionalCELOptions` injection hook): the two PRs touch disjoint files and can merge in any order
- The orthogonal "pool of N instances" approach was considered but rejected for this PR because it changes the implicit single-instance contract for plugin authors. This PR is a strictly conservative change (same serialization, just cancellable)

## Risks

- Goroutines that previously blocked indefinitely on the mutex (waiting for an `Unlock`) now exit early on ctx cancel. Code that depended on the synchronous "Call completes regardless of ctx" semantics would change behavior. I am not aware of any such consumer; in normal gRPC server flow, ctx cancel is the expected exit signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)