### PR TITLE
Make lock acquisition for CEL plugins cancellable

### DIFF
--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -733,6 +733,7 @@ func (i *CELPluginInstance) startGC(ctx context.Context) error {
 		// Acquire timed out (or the ctx was canceled). Skip this GC tick;
 		// the next enqueueGC tick will retry. Do NOT call Release here:
 		// semaphore is unchanged on Acquire failure.
+		span.SetAttributes(trace.StringAttr("acquire_status", "cancelled"))
 		log.Logger(ctx).WarnContext(ctx, fmt.Sprintf("grpc-federation: skipping GC because instance lock could not be acquired within %s: %v", gcWaitForSemTimeout, err))
 		return nil
 	}
@@ -786,6 +787,7 @@ func (i *CELPluginInstance) Call(ctx context.Context, fn *CELFunction, md metada
 	if err := i.sem.Acquire(ctx, 1); err != nil {
 		// Per semaphore.Weighted docs: "On failure, returns ctx.Err() and
 		// leaves the semaphore unchanged." Do NOT call Release on this path.
+		span.SetAttributes(trace.StringAttr("acquire_status", "cancelled"))
 		return nil, err
 	}
 	defer i.sem.Release(1)

--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -711,10 +711,10 @@ func (i *CELPluginInstance) enqueueGC() {
 	}
 }
 
-// timeout to acquire semaphore for GC
+// timeout to acquire semaphore for GC.
 var gcWaitForSemTimeout = 10 * time.Second
 
-// timeout for a GC run
+// timeout for a GC run.
 var gcRunUntilTimeout = 10 * time.Second
 
 func (i *CELPluginInstance) startGC(ctx context.Context) error {
@@ -730,7 +730,7 @@ func (i *CELPluginInstance) startGC(ctx context.Context) error {
 		// Acquire timed out (or the ctx was canceled). Skip this GC tick;
 		// the next enqueueGC tick will retry. Do NOT call Release here:
 		// semaphore is unchanged on Acquire failure.
-		span.SetAttributes(trace.StringAttr("acquire_status", "cancelled"))
+		span.SetAttributes(trace.StringAttr("acquire_status", "canceled"))
 		log.Logger(ctx).WarnContext(ctx, fmt.Sprintf("grpc-federation: skipping GC because instance lock could not be acquired within %s: %v", gcWaitForSemTimeout, err))
 		return nil
 	}
@@ -782,7 +782,7 @@ func (i *CELPluginInstance) Call(ctx context.Context, fn *CELFunction, md metada
 	if err := i.sem.Acquire(ctx, 1); err != nil {
 		// Per semaphore.Weighted docs: "On failure, returns ctx.Err() and
 		// leaves the semaphore unchanged." Do NOT call Release on this path.
-		span.SetAttributes(trace.StringAttr("acquire_status", "cancelled"))
+		span.SetAttributes(trace.StringAttr("acquire_status", "canceled"))
 		return nil, err
 	}
 	defer i.sem.Release(1)

--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -415,9 +415,11 @@ func (p *CELPlugin) createInstance(ctx context.Context) (*CELPluginInstance, err
 		gcQueue:          make(chan struct{}, gcQueueLength),
 		gcErrCh:          make(chan error, 1),
 		instanceModErrCh: make(chan error, 1),
-		// sem serializes invocations into the WASM instance with capacity 1
-		// (equivalent to sync.Mutex), but Acquire is context-aware so that
-		// upstream cancellation can free parked goroutines.
+		// This semaphore functions as a sync.Mutex (since it has capacity 1), but unlike sync.Mutex,
+		// it is context-aware, so that an upstream cancellation during Acquire() will cause the call to
+		// fail with an error.
+		// Calls to the plugin are serialized so that it only processes one call at a time. This removes
+		// the need to attach an ID to each call.
 		sem:      semaphore.NewWeighted(1),
 		cancelFn: cancel,
 	}
@@ -571,12 +573,10 @@ type CELPluginInstance struct {
 	instanceModErr   error
 	gcErrCh          chan error
 	closed           bool
-	// sem is a capacity-1 weighted semaphore that serializes calls into the
-	// underlying WASM instance, replacing what was previously a sync.Mutex.
-	// Acquire(ctx, 1) is context-aware: when the caller's context is canceled
-	// while waiting, Acquire returns ctx.Err() and the goroutine (along with
-	// its stack, function arguments, and trace span) can be released, instead
-	// of remaining parked indefinitely as it would on sync.Mutex.Lock().
+	// sem always has capacity 1, so it functions as a sync.Mutex, but unlike sync.Mutex,
+	// it is context-aware, so that an upstream cancellation during Acquire() will cause the call to
+	// fail with an error.
+
 	sem      *semaphore.Weighted
 	gcQueue  chan struct{}
 	cancelFn context.CancelFunc
@@ -662,8 +662,8 @@ func (i *CELPluginInstance) Close() error {
 
 	// Close is called during shutdown and must wait for any in-flight call to
 	// complete before tearing down resources. Acquire with a Background ctx
-	// blocks until success and never returns an error, preserving the
-	// previous sync.Mutex.Lock() semantic on this path.
+	// blocks until success (since the background ctx is never canceled), so it will never
+	// actually return an error on this path.
 	if err := i.sem.Acquire(context.Background(), 1); err != nil {
 		return err
 	}
@@ -722,11 +722,8 @@ func (i *CELPluginInstance) startGC(ctx context.Context) error {
 	defer span.End()
 
 	// GC is not bound to any user request context. Use a fresh
-	// Background-derived ctx with gcWaitForSemTimeout so that if the semaphore is
-	// held by an in-flight Call for longer than gcWaitForSemTimeout, we abandon
-	// this GC attempt rather than blocking the GC goroutine forever. The
-	// previous sync.Mutex.Lock() could not time out, so this is also a
-	// strict improvement on top of context-awareness.
+	// Background-derived ctx with gcWaitForSemTimeout, so that if the semaphore
+	// can't be acquired, we abandon this GC attempt rather than blocking the GC goroutine forever.
 	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), gcWaitForSemTimeout)
 	defer acquireCancel()
 	if err := i.sem.Acquire(acquireCtx, 1); err != nil {
@@ -779,11 +776,9 @@ func (i *CELPluginInstance) Call(ctx context.Context, fn *CELFunction, md metada
 	ctx, span := trace.Trace(ctx, "Call")
 	defer span.End()
 
-	// Acquire is context-aware. If ctx is canceled (upstream gateway timeout
-	// or client disconnect) while waiting for the in-flight call to finish,
-	// Acquire returns ctx.Err() and this goroutine — along with its stack,
-	// arguments, and the trace span opened above — can be released, instead
-	// of staying parked on a non-cancellable sync.Mutex.Lock().
+	// If the context is canceled while we are waiting to acquire the semaphore, give up and return an error.
+	// This prevents waiting calls from blocking forever, and allows caller resources to be freed
+	// (goroutine stack+args+span).
 	if err := i.sem.Acquire(ctx, 1); err != nil {
 		// Per semaphore.Weighted docs: "On failure, returns ctx.Err() and
 		// leaves the semaphore unchanged." Do NOT call Release on this path.

--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -711,26 +711,29 @@ func (i *CELPluginInstance) enqueueGC() {
 	}
 }
 
-// timeout for runtime.GC() to 10 seconds.
-var gcWaitTimeout = 10 * time.Second
+// timeout to acquire semaphore for GC
+var gcWaitForSemTimeout = 10 * time.Second
+
+// timeout for a GC run
+var gcRunUntilTimeout = 10 * time.Second
 
 func (i *CELPluginInstance) startGC(ctx context.Context) error {
 	ctx, span := trace.Trace(ctx, "github.com/mercari/grpc-federation.CELPluginInstance.startGC")
 	defer span.End()
 
 	// GC is not bound to any user request context. Use a fresh
-	// Background-derived ctx with gcWaitTimeout so that if the semaphore is
-	// held by an in-flight Call for longer than gcWaitTimeout, we abandon
+	// Background-derived ctx with gcWaitForSemTimeout so that if the semaphore is
+	// held by an in-flight Call for longer than gcWaitForSemTimeout, we abandon
 	// this GC attempt rather than blocking the GC goroutine forever. The
 	// previous sync.Mutex.Lock() could not time out, so this is also a
 	// strict improvement on top of context-awareness.
-	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), gcWaitTimeout)
+	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), gcWaitForSemTimeout)
 	defer acquireCancel()
 	if err := i.sem.Acquire(acquireCtx, 1); err != nil {
 		// Acquire timed out (or the ctx was canceled). Skip this GC tick;
 		// the next enqueueGC tick will retry. Do NOT call Release here:
 		// semaphore is unchanged on Acquire failure.
-		log.Logger(ctx).WarnContext(ctx, fmt.Sprintf("grpc-federation: skipping GC because instance lock could not be acquired within %s: %v", gcWaitTimeout, err))
+		log.Logger(ctx).WarnContext(ctx, fmt.Sprintf("grpc-federation: skipping GC because instance lock could not be acquired within %s: %v", gcWaitForSemTimeout, err))
 		return nil
 	}
 	defer i.sem.Release(1)
@@ -739,7 +742,7 @@ func (i *CELPluginInstance) startGC(ctx context.Context) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, gcWaitTimeout)
+	ctx, cancel := context.WithTimeout(ctx, gcRunUntilTimeout)
 	defer cancel()
 
 	_ = i.write(ctx, []byte(GCCommand))

--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -281,7 +281,7 @@ func (p *CELPlugin) Call(ctx context.Context, fn *CELFunction, args ...ref.Val) 
 	}
 	instance, err := p.getInstance(ctx)
 	if err != nil {
-		return types.NewErrFromString(err.Error())
+		return toCELErr(err)
 	}
 	span.SetAttributes(trace.StringAttr("instance_id", instance.id))
 	ret, err := instance.Call(ctx, fn, md, args...)
@@ -295,16 +295,16 @@ func (p *CELPlugin) Call(ctx context.Context, fn *CELFunction, args ...ref.Val) 
 			// Since getInstance() always returns an available instance, it will return the backup instance if the active instance has been closed.
 			instance, err := p.getInstance(ctx)
 			if err != nil {
-				return types.NewErrFromString(err.Error())
+				return toCELErr(err)
 			}
 			span.SetAttributes(trace.StringAttr("instance_id", instance.id))
 			retryRet, err := instance.Call(ctx, fn, md, args...)
 			if err != nil {
-				return types.NewErrFromString(err.Error())
+				return toCELErr(err)
 			}
 			return retryRet
 		} else {
-			return types.NewErrFromString(err.Error())
+			return toCELErr(err)
 		}
 	}
 	return ret

--- a/grpc/federation/cel/plugin.go
+++ b/grpc/federation/cel/plugin.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -414,7 +415,11 @@ func (p *CELPlugin) createInstance(ctx context.Context) (*CELPluginInstance, err
 		gcQueue:          make(chan struct{}, gcQueueLength),
 		gcErrCh:          make(chan error, 1),
 		instanceModErrCh: make(chan error, 1),
-		cancelFn:         cancel,
+		// sem serializes invocations into the WASM instance with capacity 1
+		// (equivalent to sync.Mutex), but Acquire is context-aware so that
+		// upstream cancellation can free parked goroutines.
+		sem:      semaphore.NewWeighted(1),
+		cancelFn: cancel,
 	}
 	instance.id = fmt.Sprintf("%s-%p", p.cfg.Name, instance)
 
@@ -566,9 +571,15 @@ type CELPluginInstance struct {
 	instanceModErr   error
 	gcErrCh          chan error
 	closed           bool
-	mu               sync.Mutex
-	gcQueue          chan struct{}
-	cancelFn         context.CancelFunc
+	// sem is a capacity-1 weighted semaphore that serializes calls into the
+	// underlying WASM instance, replacing what was previously a sync.Mutex.
+	// Acquire(ctx, 1) is context-aware: when the caller's context is canceled
+	// while waiting, Acquire returns ctx.Err() and the goroutine (along with
+	// its stack, function arguments, and trace span) can be released, instead
+	// of remaining parked indefinitely as it would on sync.Mutex.Lock().
+	sem      *semaphore.Weighted
+	gcQueue  chan struct{}
+	cancelFn context.CancelFunc
 }
 
 const PluginProtocolVersion = 2
@@ -589,8 +600,12 @@ func (i *CELPluginInstance) ValidatePlugin(ctx context.Context) error {
 	ctx, span := trace.Trace(ctx, "ValidatePlugin")
 	defer span.End()
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	if err := i.sem.Acquire(ctx, 1); err != nil {
+		// Acquire returns ctx.Err() on cancellation and leaves the semaphore
+		// unchanged, so Release must NOT be called on this path.
+		return err
+	}
+	defer i.sem.Release(1)
 
 	if err := i.write(ctx, []byte(VersionCommand)); err != nil {
 		return fmt.Errorf("failed to send cel protocol version command: %w", err)
@@ -645,8 +660,14 @@ func (i *CELPluginInstance) Close() error {
 		return nil
 	}
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	// Close is called during shutdown and must wait for any in-flight call to
+	// complete before tearing down resources. Acquire with a Background ctx
+	// blocks until success and never returns an error, preserving the
+	// previous sync.Mutex.Lock() semantic on this path.
+	if err := i.sem.Acquire(context.Background(), 1); err != nil {
+		return err
+	}
+	defer i.sem.Release(1)
 
 	return i.close()
 }
@@ -697,8 +718,22 @@ func (i *CELPluginInstance) startGC(ctx context.Context) error {
 	ctx, span := trace.Trace(ctx, "github.com/mercari/grpc-federation.CELPluginInstance.startGC")
 	defer span.End()
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	// GC is not bound to any user request context. Use a fresh
+	// Background-derived ctx with gcWaitTimeout so that if the semaphore is
+	// held by an in-flight Call for longer than gcWaitTimeout, we abandon
+	// this GC attempt rather than blocking the GC goroutine forever. The
+	// previous sync.Mutex.Lock() could not time out, so this is also a
+	// strict improvement on top of context-awareness.
+	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), gcWaitTimeout)
+	defer acquireCancel()
+	if err := i.sem.Acquire(acquireCtx, 1); err != nil {
+		// Acquire timed out (or the ctx was canceled). Skip this GC tick;
+		// the next enqueueGC tick will retry. Do NOT call Release here:
+		// semaphore is unchanged on Acquire failure.
+		log.Logger(ctx).WarnContext(ctx, fmt.Sprintf("grpc-federation: skipping GC because instance lock could not be acquired within %s: %v", gcWaitTimeout, err))
+		return nil
+	}
+	defer i.sem.Release(1)
 
 	if i.closed {
 		return nil
@@ -740,8 +775,17 @@ func (i *CELPluginInstance) Call(ctx context.Context, fn *CELFunction, md metada
 	ctx, span := trace.Trace(ctx, "Call")
 	defer span.End()
 
-	i.mu.Lock()
-	defer i.mu.Unlock()
+	// Acquire is context-aware. If ctx is canceled (upstream gateway timeout
+	// or client disconnect) while waiting for the in-flight call to finish,
+	// Acquire returns ctx.Err() and this goroutine — along with its stack,
+	// arguments, and the trace span opened above — can be released, instead
+	// of staying parked on a non-cancellable sync.Mutex.Lock().
+	if err := i.sem.Acquire(ctx, 1); err != nil {
+		// Per semaphore.Weighted docs: "On failure, returns ctx.Err() and
+		// leaves the semaphore unchanged." Do NOT call Release on this path.
+		return nil, err
+	}
+	defer i.sem.Release(1)
 
 	if err := i.sendRequest(ctx, fn, md, args...); err != nil {
 		return nil, err

--- a/grpc/federation/cel/plugin_err.go
+++ b/grpc/federation/cel/plugin_err.go
@@ -1,0 +1,38 @@
+package cel
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// ctxStatusErr attaches a gRPC status to context.Canceled /
+// context.DeadlineExceeded so that callers downstream of cel-go's
+// *types.Err round-trip can recover the correct grpc code via
+// status.FromError. Without it, ctx errors surface as codes.Unknown.
+type ctxStatusErr struct{ err error }
+
+func (e *ctxStatusErr) Error() string { return e.err.Error() }
+func (e *ctxStatusErr) Unwrap() error { return e.err }
+func (e *ctxStatusErr) GRPCStatus() *grpcstatus.Status {
+	if errors.Is(e.err, context.DeadlineExceeded) {
+		return grpcstatus.New(grpccodes.DeadlineExceeded, e.err.Error())
+	}
+	return grpcstatus.New(grpccodes.Canceled, e.err.Error())
+}
+
+// toCELErr converts a Go error returned from a plugin Call into a CEL
+// ref.Val. For context cancellation/deadline errors it preserves the
+// unwrap chain (and the gRPC status via ctxStatusErr) by going through
+// types.WrapErr; for any other error it falls back to NewErrFromString,
+// which is the historical behavior.
+func toCELErr(err error) ref.Val {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return types.WrapErr(&ctxStatusErr{err: err})
+	}
+	return types.NewErrFromString(err.Error())
+}

--- a/grpc/federation/cel/plugin_err.go
+++ b/grpc/federation/cel/plugin_err.go
@@ -13,7 +13,7 @@ import (
 // ctxStatusErr attaches a gRPC status to context.Canceled /
 // context.DeadlineExceeded so that callers downstream of cel-go's
 // *types.Err round-trip can recover the correct grpc code via
-// status.FromError. Without it, ctx errors surface as codes.Unknown.
+// status.FromError. Without it, ctx errors would be converted to codes.Unknown.
 type ctxStatusErr struct{ err error }
 
 func (e *ctxStatusErr) Error() string { return e.err.Error() }
@@ -28,8 +28,7 @@ func (e *ctxStatusErr) GRPCStatus() *grpcstatus.Status {
 // toCELErr converts a Go error returned from a plugin Call into a CEL
 // ref.Val. For context cancellation/deadline errors it preserves the
 // unwrap chain (and the gRPC status via ctxStatusErr) by going through
-// types.WrapErr; for any other error it falls back to NewErrFromString,
-// which is the historical behavior.
+// types.WrapErr; for any other error it falls back to NewErrFromString.
 func toCELErr(err error) ref.Val {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return types.WrapErr(&ctxStatusErr{err: err})

--- a/grpc/federation/cel/plugin_err_test.go
+++ b/grpc/federation/cel/plugin_err_test.go
@@ -1,0 +1,81 @@
+package cel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+func TestToCELErr_PreservesContextCanceled(t *testing.T) {
+	val := toCELErr(context.Canceled)
+	err, ok := val.(error)
+	if !ok {
+		t.Fatalf("expected ref.Val to satisfy error, got %T", val)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false, want true")
+	}
+	st, ok := grpcstatus.FromError(err)
+	if !ok {
+		t.Fatalf("status.FromError did not find a status")
+	}
+	if st.Code() != grpccodes.Canceled {
+		t.Fatalf("grpc code = %s, want Canceled", st.Code())
+	}
+}
+
+func TestToCELErr_PreservesContextDeadlineExceeded(t *testing.T) {
+	val := toCELErr(context.DeadlineExceeded)
+	err := val.(error)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("errors.Is(err, context.DeadlineExceeded) = false, want true")
+	}
+	st, _ := grpcstatus.FromError(err)
+	if st.Code() != grpccodes.DeadlineExceeded {
+		t.Fatalf("grpc code = %s, want DeadlineExceeded", st.Code())
+	}
+}
+
+func TestToCELErr_PreservesWrappedContextCanceled(t *testing.T) {
+	wrapped := fmt.Errorf("plugin Acquire failed: %w", context.Canceled)
+	val := toCELErr(wrapped)
+	err := val.(error)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is on wrapped chain = false, want true")
+	}
+	st, _ := grpcstatus.FromError(err)
+	if st.Code() != grpccodes.Canceled {
+		t.Fatalf("grpc code = %s, want Canceled", st.Code())
+	}
+}
+
+func TestToCELErr_PassesThroughOtherErrors(t *testing.T) {
+	val := toCELErr(errors.New("plugin blew up"))
+	err := val.(error)
+
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("non-context error should not match context.Canceled")
+	}
+	st, _ := grpcstatus.FromError(err)
+	if st.Code() != grpccodes.Unknown {
+		t.Fatalf("grpc code = %s, want Unknown for non-context error", st.Code())
+	}
+	if err.Error() != "plugin blew up" {
+		t.Fatalf("message = %q, want %q", err.Error(), "plugin blew up")
+	}
+}
+
+func TestToCELErr_ResultIsCELError(t *testing.T) {
+	val := toCELErr(context.Canceled)
+	if !types.IsError(val) {
+		t.Fatalf("types.IsError(val) = false, want true")
+	}
+}

--- a/grpc/federation/cel/plugin_test.go
+++ b/grpc/federation/cel/plugin_test.go
@@ -5,12 +5,17 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestPlugin(t *testing.T) {
@@ -61,5 +66,197 @@ func TestPlugin(t *testing.T) {
 	}
 	if int(iv) != 10 {
 		t.Fatalf("failed to get response value: %v", iv)
+	}
+}
+
+// newInstanceForSemaphoreTest constructs a minimally-initialized
+// CELPluginInstance suitable for exercising the semaphore-acquisition path of
+// Call/ValidatePlugin without spinning up a real WASM module. It only
+// initializes fields that the methods touch before sem.Acquire returns.
+func newInstanceForSemaphoreTest() *CELPluginInstance {
+	return &CELPluginInstance{
+		name:             "sem-test",
+		sem:              semaphore.NewWeighted(1),
+		reqCh:            make(chan []byte, 1),
+		resCh:            make(chan []byte),
+		gcErrCh:          make(chan error, 1),
+		instanceModErrCh: make(chan error, 1),
+		gcQueue:          make(chan struct{}, 1),
+	}
+}
+
+// TestCallReleasesOnCtxCancel verifies that when a goroutine is blocked on
+// Call() waiting for the semaphore (i.e. another call holds the instance),
+// canceling that goroutine's ctx unblocks it promptly with ctx.Err(), instead
+// of leaking the goroutine + arguments + span until the previous holder
+// finally returns.
+//
+// Before this change, Call() acquired sync.Mutex.Lock() which is not
+// context-aware, so a parked goroutine could not be woken by ctx.Done().
+func TestCallReleasesOnCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	inst := newInstanceForSemaphoreTest()
+
+	// Simulate an in-flight call holding the instance lock.
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type result struct {
+		val ref.Val
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		fn := &CELFunction{Name: "f", ID: "f", Return: types.IntType}
+		v, err := inst.Call(ctx, fn, metadata.MD{})
+		done <- result{val: v, err: err}
+	}()
+
+	// Give the goroutine a moment to actually park on Acquire.
+	time.Sleep(20 * time.Millisecond)
+
+	select {
+	case <-done:
+		t.Fatal("Call returned before ctx cancel; expected it to be parked on the semaphore")
+	default:
+	}
+
+	cancel()
+
+	select {
+	case r := <-done:
+		if !errors.Is(r.err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", r.err)
+		}
+		if r.val != nil {
+			t.Fatalf("expected nil value on cancel, got %v", r.val)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call did not return within 2s after ctx cancel; semaphore is not context-aware")
+	}
+}
+
+// TestCallReleasesOnCtxDeadline verifies deadline propagation: when the
+// caller's ctx has a deadline, Call() blocked on the semaphore must return
+// context.DeadlineExceeded shortly after the deadline.
+func TestCallReleasesOnCtxDeadline(t *testing.T) {
+	t.Parallel()
+
+	inst := newInstanceForSemaphoreTest()
+
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	const deadline = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		fn := &CELFunction{Name: "f", ID: "f", Return: types.IntType}
+		_, err := inst.Call(ctx, fn, metadata.MD{})
+		done <- result{err: err}
+	}()
+
+	select {
+	case r := <-done:
+		elapsed := time.Since(start)
+		if !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Fatalf("expected context.DeadlineExceeded, got %v", r.err)
+		}
+		// Sanity check: should be roughly the deadline, not a hang.
+		if elapsed > 2*time.Second {
+			t.Fatalf("Call returned only after %v, expected ~%v", elapsed, deadline)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Call did not return within 2s after deadline; semaphore is not context-aware")
+	}
+}
+
+// TestValidatePluginReleasesOnCtxCancel verifies the same context-aware
+// behavior on ValidatePlugin's semaphore acquisition path.
+func TestValidatePluginReleasesOnCtxCancel(t *testing.T) {
+	t.Parallel()
+
+	inst := newInstanceForSemaphoreTest()
+
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- inst.ValidatePlugin(ctx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidatePlugin did not return within 2s after ctx cancel")
+	}
+}
+
+// TestStartGCSkipsOnAcquireTimeout verifies that the GC code path skips when
+// the semaphore is held by an in-flight call for longer than gcWaitTimeout.
+// This preserves the pre-existing "skip on contention" behavior while making
+// the wait bounded (it was previously unbounded under sync.Mutex).
+func TestStartGCSkipsOnAcquireTimeout(t *testing.T) {
+	// Lower gcWaitTimeout for the duration of this test so it runs quickly.
+	t.Cleanup(func() { gcWaitTimeout = 10 * time.Second })
+	gcWaitTimeout = 50 * time.Millisecond
+
+	inst := newInstanceForSemaphoreTest()
+
+	// Simulate a long-running call holding the semaphore.
+	if err := inst.sem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("failed to pre-acquire semaphore: %v", err)
+	}
+	defer inst.sem.Release(1)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- inst.startGC(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("expected nil error on GC skip, got %v", err)
+		}
+		// startGC must have given up around gcWaitTimeout, not blocked forever.
+		if elapsed > 1*time.Second {
+			t.Fatalf("startGC returned only after %v, expected ~%v", elapsed, gcWaitTimeout)
+		}
+		// And it must NOT have called cancelFn or pushed to gcErrCh in the
+		// skip path (those are reserved for the GC-hang path).
+		select {
+		case <-inst.gcErrCh:
+			t.Fatal("gcErrCh should not receive a value when GC is skipped on Acquire timeout")
+		default:
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startGC did not return within 2s; expected skip after Acquire timeout")
 	}
 }

--- a/grpc/federation/cel/plugin_test.go
+++ b/grpc/federation/cel/plugin_test.go
@@ -217,13 +217,13 @@ func TestValidatePluginReleasesOnCtxCancel(t *testing.T) {
 }
 
 // TestStartGCSkipsOnAcquireTimeout verifies that the GC code path skips when
-// the semaphore is held by an in-flight call for longer than gcWaitTimeout.
+// the semaphore is held by an in-flight call for longer than gcWaitForSemTimeout.
 // This preserves the pre-existing "skip on contention" behavior while making
 // the wait bounded (it was previously unbounded under sync.Mutex).
 func TestStartGCSkipsOnAcquireTimeout(t *testing.T) {
-	// Lower gcWaitTimeout for the duration of this test so it runs quickly.
-	t.Cleanup(func() { gcWaitTimeout = 10 * time.Second })
-	gcWaitTimeout = 50 * time.Millisecond
+	// Lower gcWaitForSemTimeout for the duration of this test so it runs quickly.
+	t.Cleanup(func() { gcWaitForSemTimeout = 10 * time.Second })
+	gcWaitForSemTimeout = 50 * time.Millisecond
 
 	inst := newInstanceForSemaphoreTest()
 
@@ -245,9 +245,9 @@ func TestStartGCSkipsOnAcquireTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected nil error on GC skip, got %v", err)
 		}
-		// startGC must have given up around gcWaitTimeout, not blocked forever.
+		// startGC must have given up around gcWaitForSemTimeout, not blocked forever.
 		if elapsed > 1*time.Second {
-			t.Fatalf("startGC returned only after %v, expected ~%v", elapsed, gcWaitTimeout)
+			t.Fatalf("startGC returned only after %v, expected ~%v", elapsed, gcWaitForSemTimeout)
 		}
 		// And it must NOT have called cancelFn or pushed to gcErrCh in the
 		// skip path (those are reserved for the GC-hang path).

--- a/grpc/federation/cel/plugin_test.go
+++ b/grpc/federation/cel/plugin_test.go
@@ -218,8 +218,6 @@ func TestValidatePluginReleasesOnCtxCancel(t *testing.T) {
 
 // TestStartGCSkipsOnAcquireTimeout verifies that the GC code path skips when
 // the semaphore is held by an in-flight call for longer than gcWaitForSemTimeout.
-// This preserves the pre-existing "skip on contention" behavior while making
-// the wait bounded (it was previously unbounded under sync.Mutex).
 func TestStartGCSkipsOnAcquireTimeout(t *testing.T) {
 	// Lower gcWaitForSemTimeout for the duration of this test so it runs quickly.
 	t.Cleanup(func() { gcWaitForSemTimeout = 10 * time.Second })


### PR DESCRIPTION
# What

Replace `sync.Mutex` with `golang.org/x/sync/semaphore.Weighted(1)` for serializing calls to `CELPluginInstance`. Using a semaphore allows us to respect cancellation of a goroutine that is waiting in the `Acquire` function (`sync.Mutex` does not respect cancellation). A call that is cancelled while waiting for the semaphore will return an error from the plugin call.

This PR also fixes an existing bug, where `plugin.go` doesn't propagate error types correctly. In particular, deadline exceeded and canceled errors were not convertable to gRPC status.

# Why

CEL plugins are single-threaded (protected by a lock on the caller-side), and if a plugin is overwhelmed, caller goroutines pile up on the lock. With `sync.Mutex`, cancellation during `Mutex.Acquire` doesn't get propagated to a waiting goroutine, so there is a risk of OOM due to too many waiting goroutines (each with a stack, plugin arguments, etc).

With the change in this PR, a request to a grpc-federation server that has to block waiting for a CEL plugin lock will stop waiting with an error, when the request hits its deadline. This improves stability of servers under load.