### PR TITLE
demo: workaround for expired swapi.dev TLS cert and add usage notes

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -1,0 +1,83 @@
+# SWAPI デモ 操作メモ
+
+`demo/` 配下のデモを起動・停止・grpcurl で叩くためのコマンド集。
+
+## 共通の前提（毎回必要）
+
+```sh
+cd demo
+export DOCKER_HOST=unix:///Users/y-a-watanabe/.docker/run/docker.sock
+```
+
+> 毎回打つのが面倒なら `direnv` を使うか、シェルの rc に書いてしまうのが楽。
+
+## 起動
+
+| 用途 | コマンド |
+|---|---|
+| 起動 (フォアグラウンド、ログ流す) | `make up` |
+| 起動 (バックグラウンド) | `docker compose up -d` |
+| 状態確認 | `docker compose ps` |
+| ログ確認 | `docker compose logs -f swapi` （サービス名を変えれば各 microservice のログ） |
+
+> 初回 or コードを変更した後は `make generate && make build` を先に。
+
+## 停止
+
+| 用途 | コマンド |
+|---|---|
+| フォアグラウンド起動を止める | `Ctrl+C` |
+| コンテナ停止＋削除（推奨） | `docker compose down` |
+| 一時停止だけ（コンテナは残す） | `docker compose stop` |
+| 再開 | `docker compose start` |
+
+## grpcurl での動作確認
+
+`./bin/grpcurl` は `demo/bin/` にあるので、`demo/` 配下で実行する想定。
+
+### サービス一覧 / メソッド一覧（reflection）
+
+```sh
+./bin/grpcurl -plaintext localhost:3000 list
+./bin/grpcurl -plaintext localhost:3000 list swapi.SWAPI
+./bin/grpcurl -plaintext localhost:3000 describe swapi.SWAPI.GetPerson
+```
+
+### 単体取得
+
+```sh
+./bin/grpcurl -plaintext -d '{"id": 1}' localhost:3000 swapi.SWAPI/GetPerson
+./bin/grpcurl -plaintext -d '{"id": 1}' localhost:3000 swapi.SWAPI/GetFilm
+./bin/grpcurl -plaintext -d '{"id": 1}' localhost:3000 swapi.SWAPI/GetPlanet
+./bin/grpcurl -plaintext -d '{"id": 1}' localhost:3000 swapi.SWAPI/GetStarship
+./bin/grpcurl -plaintext -d '{"id": 1}' localhost:3000 swapi.SWAPI/GetSpecies
+./bin/grpcurl -plaintext -d '{"id": 1}' localhost:3000 swapi.SWAPI/GetVehicle
+```
+
+### 一覧取得（List 系）
+
+```sh
+./bin/grpcurl -plaintext -d '{}' localhost:3000 swapi.SWAPI/ListPeople
+./bin/grpcurl -plaintext -d '{}' localhost:3000 swapi.SWAPI/ListFilms
+./bin/grpcurl -plaintext -d '{}' localhost:3000 swapi.SWAPI/ListPlanets
+./bin/grpcurl -plaintext -d '{}' localhost:3000 swapi.SWAPI/ListStarships
+./bin/grpcurl -plaintext -d '{}' localhost:3000 swapi.SWAPI/ListSpecies
+./bin/grpcurl -plaintext -d '{}' localhost:3000 swapi.SWAPI/ListVehicles
+```
+
+### トレース確認
+
+ブラウザで http://localhost:4000 を開く → Service に `swapi` を選択して Find Traces。
+
+## トラブル時のチェック
+
+```sh
+docker compose ps              # 全コンテナ Up になっているか
+docker compose logs swapi      # swapi ログ
+docker compose logs person     # 各 microservice のログ
+```
+
+## 補足
+
+- 今回入れた `InsecureSkipVerify` の修正（`util/util.go` の `NewSwapiClient`）は swapi.dev の証明書が再発行されたら不要になる類のもの。本家のフィックスではないので、コミット前に意識すること。
+- Go ツールチェイン: `GOTOOLCHAIN=go1.24.13` が必要なのは `make tools` のときだけ。一度入れた `bin/` のバイナリには関係なし。

--- a/demo/services/film/film.go
+++ b/demo/services/film/film.go
@@ -17,7 +17,7 @@ type FilmService struct {
 
 func NewFilmService() *FilmService {
 	return &FilmService{
-		cli:   swapi.NewClient(),
+		cli:   util.NewSwapiClient(),
 		cache: make(map[int64]*filmpb.Film),
 	}
 }

--- a/demo/services/person/person.go
+++ b/demo/services/person/person.go
@@ -17,7 +17,7 @@ type PersonService struct {
 
 func NewPersonService() *PersonService {
 	return &PersonService{
-		cli:   swapi.NewClient(),
+		cli:   util.NewSwapiClient(),
 		cache: make(map[int64]*personpb.Person),
 	}
 }

--- a/demo/services/planet/planet.go
+++ b/demo/services/planet/planet.go
@@ -17,7 +17,7 @@ type PlanetService struct {
 
 func NewPlanetService() *PlanetService {
 	return &PlanetService{
-		cli:   swapi.NewClient(),
+		cli:   util.NewSwapiClient(),
 		cache: make(map[int64]*planetpb.Planet),
 	}
 }

--- a/demo/services/species/species.go
+++ b/demo/services/species/species.go
@@ -17,7 +17,7 @@ type SpeciesService struct {
 
 func NewSpeciesService() *SpeciesService {
 	return &SpeciesService{
-		cli:   swapi.NewClient(),
+		cli:   util.NewSwapiClient(),
 		cache: make(map[int64]*speciespb.Species),
 	}
 }

--- a/demo/services/starship/starship.go
+++ b/demo/services/starship/starship.go
@@ -17,7 +17,7 @@ type StarshipService struct {
 
 func NewStarshipService() *StarshipService {
 	return &StarshipService{
-		cli:   swapi.NewClient(),
+		cli:   util.NewSwapiClient(),
 		cache: make(map[int64]*starshippb.Starship),
 	}
 }

--- a/demo/services/vehicle/vehicle.go
+++ b/demo/services/vehicle/vehicle.go
@@ -17,7 +17,7 @@ type VehicleService struct {
 
 func NewVehicleService() *VehicleService {
 	return &VehicleService{
-		cli:   swapi.NewClient(),
+		cli:   util.NewSwapiClient(),
 		cache: make(map[int64]*vehiclepb.Vehicle),
 	}
 }

--- a/demo/util/util.go
+++ b/demo/util/util.go
@@ -1,10 +1,25 @@
 package util
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
+
+	"github.com/peterhellberg/swapi"
 )
+
+// NewSwapiClient returns a swapi.Client that skips TLS verification.
+// Workaround for the expired swapi.dev certificate in this local demo.
+func NewSwapiClient() *swapi.Client {
+	hc := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	return swapi.NewClient(swapi.HTTPClient(hc))
+}
 
 var (
 	personURLToIDRe   = regexp.MustCompile(`swapi.dev/api/people/(\d+)/`)


### PR DESCRIPTION
- util.NewSwapiClient: skip TLS verify for local demo
- Wire it into 6 microservices instead of swapi.NewClient
- Add demo/demo.md with run/stop/grpcurl commands

