### PR TITLE
(docs): fix typos and broken links in documentation

### DIFF
--- a/docs/cel.md
+++ b/docs/cel.md
@@ -16,12 +16,14 @@ In addition to the standard CEL operations, the gRPC Federation supports a numbe
 - [grpc.federation.metadata APIs](./cel/metadata.md)
 - [grpc.federation.rand APIs](./cel/rand.md)
 - [grpc.federation.regexp APIs](./cel/regexp.md)
+- [grpc.federation.strings APIs](./cel/strings.md)
 - [grpc.federation.time APIs](./cel/time.md)
+- [grpc.federation.url APIs](./cel/url.md)
 - [grpc.federation.uuid APIs](./cel/uuid.md)
 
 ## Refer to the defined variable
 
-If you have defined variables using [`def`](#grpcfederationmessagedef) feature, you can use them in CEL.  
+If you have defined variables using [`def`](./references.md#grpcfederationmessagedef) feature, you can use them in CEL.  
 Also, the message argument should be `$.` can be used to refer to them.
 
 ## error

--- a/docs/cel/uuid.md
+++ b/docs/cel/uuid.md
@@ -96,7 +96,7 @@ FYI: https://pkg.go.dev/github.com/google/uuid#Parse
 
 ```cel
 grpc.federation.uuid.parse('daa4728d-159f-4fc2-82cf-cae915d54e08')
-gprc.federation.uuid.parse(gprc.federation.uuid.new().string())
+grpc.federation.uuid.parse(grpc.federation.uuid.new().string())
 ```
 
 ## validate

--- a/docs/code_generation_plugin.md
+++ b/docs/code_generation_plugin.md
@@ -133,4 +133,4 @@ grpc-federation-generator ./proto/federation/federation.proto
 
 ## 6. Run your code generator
 
-The plugin is executed and the `resover_test.go` file is created in the current working directory.
+The plugin is executed and the `resolver_test.go` file is created in the current working directory.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ plugins:
     out: gen
     opt:
       - paths=source_relative
-  - plugin: buf.build/community/mercari-grpc-federation:v1.0.0
+  - plugin: buf.build/community/mercari-grpc-federation:v1.27.0
     out: gen
     opt:
       - paths=source_relative
@@ -104,12 +104,12 @@ go install github.com/mercari/grpc-federation/cmd/protoc-gen-grpc-federation@lat
 ### 2.2. Put gRPC Federation proto file to the import path
 
 Copy the gRPC Federation proto file to the import path.
-gRPC Federation's proto file is [here](./proto/grpc/federation/federation.proto).
+gRPC Federation's proto file is [here](../proto/grpc/federation/federation.proto).
 
 Also, gRPC Federation depends on the following proto file. These are located in the `proto_deps` directory and should be added to the import path if necessary.
 
-- [`google/rpc/code.proto`](./proto_deps/google/rpc/code.proto)
-- [`google/rpc/error_details.proto`](./proto_deps/google/rpc/error_details.proto)
+- [`google/rpc/code.proto`](../proto_deps/google/rpc/code.proto)
+- [`google/rpc/error_details.proto`](../proto_deps/google/rpc/error_details.proto)
 
 ```console
 git clone https://github.com/mercari/grpc-federation.git

--- a/docs/references.md
+++ b/docs/references.md
@@ -1444,7 +1444,7 @@ A single case in a `switch` expression. Cases are evaluated in order, and the fi
 | [`if`](#grpcfederationmessagedefswitchcaseif) | [CEL](./cel.md)             | required             |
 | [`by`](#grpcfederationmessagedefswitchcaseby) | [CEL](./cel.md)             | required             |
 
-## (gprc.federation.message).def.switch.case.def
+## (grpc.federation.message).def.switch.case.def
 
 `def` defines a variable scoped to the case block.
 
@@ -1467,7 +1467,7 @@ The default case that is evaluated when none of the switch cases match. Variable
 | [`def`](#grpcfederationmessagedef)               | repeated VariableDefinition | optional             |
 | [`by`](#grpcfederationmessagedefswitchdefaultby) | [CEL](./cel.md)             | required             |
 
-## (gprc.federation.message).def.switch.default.def
+## (grpc.federation.message).def.switch.default.def
 
 `def` defines a variable scoped to the default block.
 


### PR DESCRIPTION
While reading through the documentation in depth to try to understand the repo, I noticed a handful of small issues and tried fixing them in one pass;

- Two section headings in `references.md` (and a code example in `cel/uuid.md`) misspell `grpc.federation` as `gprc.federation`. The uuid example would fail if copy-pasted.
- Three links in `installation.md` point at `./proto/...` and `./proto_deps/...`, which resolve to nonexistent `docs/...` paths on GitHub; they now point one directory up.
- The buf plugin example in `installation.md` pins `mercari-grpc-federation:v1.0.0`; bumped it to `v1.27.0`, the latest version published on the BSR.
- The CEL API index in `cel.md` is missing entries for the `strings` and `url` libraries even though both doc pages exist. Also pointed the `def` link in the same file at `references.md`, where that anchor actually lives.
- `code_generation_plugin.md` refers to the generated file as `resover_test.go` instead of `resolver_test.go`.

Documentation-only change; no functional impact. Hopefully it will helps future contributors (myself included) to navigate through the docs to learn the repo